### PR TITLE
Plan A: ZFS storage backend foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Enroot is an unprivileged container runtime — an "enhanced unprivileged `chroot(1)`" that imports Docker/OCI images and runs them inside user/mount namespaces with little-to-no isolation overhead. It is a CLI-only tool (no daemon), targeted at HPC and multi-user systems. The user-facing surface is the `enroot` bash script plus a handful of small static C helpers.
+
+## Build / develop
+
+The project uses a plain `Makefile` (no autotools, no test suite). Several pieces are non-obvious:
+
+- **Submodules are mandatory.** `make` invokes `git submodule update --init` to pull `deps/musl`, `deps/libbsd`, `deps/linux-headers`, `deps/makeself`. A fresh clone without `--recurse-submodules` will not build until you run `make deps` (or any `make` target — `deps` is a prerequisite).
+- **Helper C binaries (`bin/enroot-*`) link statically against musl**, not the system glibc. The Makefile rewrites `CC` to `deps/dist/musl/bin/musl-gcc` (or `musl-clang`) for those targets and adds `-static-pie`. To build with the system toolchain instead, set `FORCE_GLIBC=1`.
+- **`enroot.in` and `conf/enroot.conf.in` are templated** with `sed` at build time — `@sysconfdir@`, `@libdir@`, `@version@` are substituted from Makefile variables. Never edit the generated `enroot` / `conf/enroot.conf` files; edit the `.in` versions.
+
+Common targets:
+
+```sh
+make                # build enroot script, conf, deps, helper utils
+make deps           # build submodules into deps/dist/ only
+make depsclean      # clean submodule build artifacts
+make mostlyclean    # remove generated enroot, conf, utils (keeps deps)
+make clean          # mostlyclean + depsclean
+make install        # install to $(DESTDIR)$(prefix), default /usr/local
+make setcap         # grant CAP_SYS_ADMIN/CAP_MKNOD to mksquashovlfs/aufs2ovlfs
+make dist           # build and tar a relocatable installation
+make deb            # build .deb via debuild (uses pkg/deb/)
+make rpm            # build .rpm via rpmbuild (uses pkg/rpm/)
+make release        # full multi-arch release via pkg/release/ docker scripts
+DEBUG=1 make        # build helpers with ASan/UBSan/leak sanitizers and -g3
+```
+
+Cross-compilation: set `CROSS_COMPILE=<triple>-` (e.g. `aarch64-linux-gnu-`); the Makefile derives `CC` and the host triple from it.
+
+There are **no automated tests**. Verification is manual: `make install` into a prefix and exercise `enroot import`/`create`/`start`. CI is limited to LGTM (`.lgtm.yml`) for static analysis on `deps/**/*.c`.
+
+## Architecture
+
+The runtime is a bash front-end plus a few small privileged-helper C binaries.
+
+**Top-level entry point: `enroot.in`** — single bash script (templated to `enroot`). It loads `enroot.conf`, exports `ENROOT_*` paths, then `source`s the libraries and dispatches subcommands (`import`, `create`, `start`, `bundle`, `export`, `list`, `remove`, `exec`, `batch`, `load`, `digest`, `info`, `version`). Subcommand handlers (`enroot::import`, `enroot::start`, …) live in this file and call into the libraries.
+
+**Library modules in `src/` (sourced, not executed):**
+- `common.sh` — logging, error formatting, `curl` wrapper, `runparts`, env/fstab parsing, locking helpers. Sourced by all others.
+- `runtime.sh` — container lifecycle: assembling environ/fstab, running pre-start hooks, invoking `enroot-mount` and `enroot-switchroot`, managing rootfs in `ENROOT_DATA_PATH`.
+- `docker.sh` — Docker Registry v2 client (auth tokens, manifest/blob fetching, image extraction). Pure bash + `curl` + `jq`.
+- `bundle.sh` — generates self-extracting `.run` bundles via `enroot-makeself` (a vendored fork of makeself).
+
+**C helpers in `bin/` (each is a single-file program):**
+- `enroot-mount` — reads an fstab and performs mounts (supports the enroot extensions: `x-create=`, `x-move`, `x-detach`, env-var substitution, `fs_passno` as ordering key).
+- `enroot-switchroot` — pivots into the rootfs and execs `/etc/rc`.
+- `enroot-nsenter` — joins existing namespaces (used by `enroot exec`).
+- `enroot-aufs2ovlfs` / `enroot-mksquashovlfs` — flatten a layered Docker overlay into a single rootfs / squashfs. These need `CAP_SYS_ADMIN` (and `CAP_MKNOD` for aufs2ovlfs) — granted by `make setcap` or by installing the `enroot+caps` package.
+
+**Configuration (`conf/`)** is split into three layered drop-in directories, each loaded from both `ENROOT_SYSCONF_PATH` (system-wide, default `/etc/enroot`) and `ENROOT_CONFIG_PATH` (per-user, default `~/.config/enroot`):
+- `hooks.d/*.sh` — pre-start bash hooks run with full host capabilities before pivot. Numeric prefix controls order. `extra/` hooks ship to `$datadir/enroot/hooks.d` and are opt-in (admin symlinks them in).
+- `mounts.d/*.fstab` — additional fstab entries merged with the image's `/etc/fstab`.
+- `environ.d/*.env` — additional env vars merged with the image's `/etc/environment`.
+
+When debugging container behavior, the order is: image `/etc/{rc,fstab,environment}` → sysconf drop-ins → user config drop-ins → CLI flags (`-e`, `-m`, `-c`, `--rc`).
+
+**Container image format:** plain squashfs. The runtime treats three files inside the rootfs specially: `/etc/rc` (entrypoint), `/etc/fstab` (mounts, with enroot extensions), `/etc/environment` (env vars). See `doc/image-format.md`.
+
+**Filesystem layout at runtime:**
+- `ENROOT_DATA_PATH` (`~/.local/share/enroot`) — extracted container rootfs trees, one per name.
+- `ENROOT_CACHE_PATH` (`~/.cache/enroot`) — registry credentials, layer cache, auth tokens (per-EUID subdir).
+- `ENROOT_RUNTIME_PATH` (`/run/enroot`) — per-container ephemeral state (assembled fstab, environ, rc, lock).
+
+## Active design proposals
+
+- **`doc/zfs.md`** — optional ZFS storage backend (`ENROOT_STORAGE_BACKEND=zfs`). Replaces `unsquashfs`-per-create with extract-once-then-`zfs clone`. Adds a `.zfs` (zfs send stream) image format and a `zfs://host/NAME` transport scheme alongside today's `.sqsh`. Introduces a shared template cache with a live/warm/cold lifecycle (knobs: `ENROOT_TEMPLATE_WARM_SECONDS`, `ENROOT_TEMPLATE_PRESSURE_THRESHOLD`; eviction is implicit on `create`, no daemon, no `enroot gc` command). Default backend (`dir`) is unchanged.
+- **`doc/plans/`** — six implementation plans (A–F) breaking the ZFS backend into independently-landable slices. Start with `doc/plans/README.md` for the index and recommended landing order (A → E → F → B → C → D). Plans add a new sourced module `src/storage_zfs.sh` (under a `zfs::` namespace) and branch in `src/runtime.sh`, `src/docker.sh` on `ENROOT_STORAGE_BACKEND`. No code changes have landed yet.
+
+## Conventions
+
+- All bash files use `set -euo pipefail; shopt -s lastpipe` and require **bash >= 4.2**.
+- Functions are namespaced with `::` (`common::log`, `runtime::start`, `docker::pull`, `enroot::import`).
+- C helpers are intentionally minimal, statically linked, and use `err()`/`errx()` from libbsd. Compiled with the strict `-Wall -Wextra -Wcast-align -Wconversion -Wsign-conversion -Werror`-adjacent flag set in the Makefile — match this style for any new C.
+- `conf/hooks/*.sh` numeric prefix encodes phase; keep new hooks consistent (10-* runs first, 99-* last; 50-* is reserved for opt-in `extra/`).
+
+## Contributing
+
+Every commit must be DCO-signed (`git commit -s`). See `CONTRIBUTING.md`. There is no separate code-style or PR-template doc.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ When debugging container behavior, the order is: image `/etc/{rc,fstab,environme
 ## Active design proposals
 
 - **`doc/zfs.md`** — optional ZFS storage backend (`ENROOT_STORAGE_BACKEND=zfs`). Replaces `unsquashfs`-per-create with extract-once-then-`zfs clone`. Adds a `.zfs` (zfs send stream) image format and a `zfs://host/NAME` transport scheme alongside today's `.sqsh`. Introduces a shared template cache with a live/warm/cold lifecycle (knobs: `ENROOT_TEMPLATE_WARM_SECONDS`, `ENROOT_TEMPLATE_PRESSURE_THRESHOLD`; eviction is implicit on `create`, no daemon, no `enroot gc` command). Default backend (`dir`) is unchanged.
-- **`doc/plans/`** — six implementation plans (A–F) breaking the ZFS backend into independently-landable slices. Start with `doc/plans/README.md` for the index and recommended landing order (A → E → F → B → C → D). Plans add a new sourced module `src/storage_zfs.sh` (under a `zfs::` namespace) and branch in `src/runtime.sh`, `src/docker.sh` on `ENROOT_STORAGE_BACKEND`. No code changes have landed yet.
+- **`doc/plans/`** — six implementation plans (A–F) breaking the ZFS backend into independently-landable slices. Start with `doc/plans/README.md` for the index and recommended landing order (A → E → F → B → C → D). Plans add a new sourced module `src/storage_zfs.sh` (under a `zfs::` namespace) and branch in `src/runtime.sh`, `src/docker.sh` on `ENROOT_STORAGE_BACKEND`. **Plan A is implemented** on `feature/zfs-foundation` (PR [zeroae/enroot#1](https://github.com/zeroae/enroot/pull/1) → `zenroot/main`); B–F are still design-only.
 
 ## Conventions
 
@@ -82,3 +82,33 @@ When debugging container behavior, the order is: image `/etc/{rc,fstab,environme
 ## Contributing
 
 Every commit must be DCO-signed (`git commit -s`). See `CONTRIBUTING.md`. There is no separate code-style or PR-template doc.
+
+## Fork workflow (zeroae/enroot)
+
+This working copy is a fork. Changes are **not destined for upstream merge** — `nvidia/enroot` is treated as a read-only source we periodically absorb from. The fork lives at `https://github.com/zeroae/enroot`.
+
+**Remotes:**
+- `origin` → `https://github.com/zeroae/enroot.git` — the fork; push here.
+- `upstream` → `https://github.com/nvidia/enroot.git` — read-only; never push.
+
+**Branches:**
+- `main` — local mirror of `upstream/main`. Never commit here directly. Refresh with `git fetch upstream && git push origin upstream/main:main`.
+- `zenroot/main` — the **fork's default branch** and integration line. All feature work lands here. Periodically rebased onto `upstream/main` (see below).
+- `feature/<name>` — short-lived. Branch off `zenroot/main`, PR back into `zenroot/main`, delete after merge.
+
+**Opening a PR** (after pushing the feature branch):
+```sh
+gh pr create --base zenroot/main --head feature/<name> --title "..." --body "..."
+```
+`zenroot/main` is the fork's default branch, so `--base` can usually be omitted, but state it explicitly to guard against accidental upstream targeting.
+
+**Absorbing upstream changes** — do this from `zenroot/main`, never on a live feature branch:
+```sh
+git checkout zenroot/main
+git fetch upstream
+git rebase upstream/main             # resolve conflicts here once
+git push --force-with-lease origin zenroot/main
+```
+Force-push is acceptable on `zenroot/main` because it's the integration branch. **Never force-push** a `feature/*` branch once it's under review; rebase only before opening the PR. If a feature branch needs to absorb the latest `zenroot/main` mid-review, prefer a merge commit over a rebase.
+
+**Plan stack:** the six plans in `doc/plans/` each map to one PR into `zenroot/main`. Recommended order is `A → E → F → B → C → D`; B/C/D/E/F all depend on A. After each plan merges, branch the next one from the freshly-merged `zenroot/main`.

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,11 @@ EMAIL    := cudatools@nvidia.com
 
 BIN := enroot
 
-SRCS := src/common.sh  \
-        src/bundle.sh  \
-        src/docker.sh  \
-        src/runtime.sh
+SRCS := src/common.sh      \
+        src/bundle.sh      \
+        src/docker.sh      \
+        src/runtime.sh     \
+        src/storage_zfs.sh
 
 DEPS := deps/dist/makeself/bin/enroot-makeself \
 

--- a/conf/enroot.conf.in
+++ b/conf/enroot.conf.in
@@ -21,6 +21,11 @@
 # Enable native overlayfs support for "enroot load" and directly starting containers from SquashFS files.
 #ENROOT_NATIVE_OVERLAYFS yes
 
+# Storage backend for the container store. "dir" = today's plain directories (default).
+# "zfs" = use ZFS datasets; ENROOT_DATA_PATH must be a ZFS dataset mountpoint with
+# create/mount/clone/destroy/snapshot delegations granted to the user. See doc/zfs.md.
+#ENROOT_STORAGE_BACKEND     dir
+
 # Remap the current user to root inside containers by default.
 #ENROOT_REMAP_ROOT          no
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -19,6 +19,10 @@ The following table describes standard paths used by the runtime:
 
 When `enroot.conf` has been read, and if there is a directory `enroot.conf.d` next to `enroot.conf`, all files in that directory matching `*.conf` will be considered, too.
 
+## Storage backend (proposal)
+
+An optional ZFS-aware storage backend is being designed. It replaces extraction-per-create with a clone-on-create model, sharing immutable templates across containers. See [ZFS backend](zfs.md) for the full design, including the `ENROOT_STORAGE_BACKEND`, `ENROOT_TEMPLATE_WARM_SECONDS`, and `ENROOT_TEMPLATE_PRESSURE_THRESHOLD` settings. The default backend (`dir`) is unchanged.
+
 ## Container configuration
 
 Common configurations can be applied to all containers by leveraging the following directories under `ENROOT_SYSCONF_PATH` (system-wide) and/or `ENROOT_CONFIG_PATH` (user-specific).

--- a/doc/plans/2026-04-29-zfs-a-foundation.md
+++ b/doc/plans/2026-04-29-zfs-a-foundation.md
@@ -1,0 +1,781 @@
+# ZFS Backend Plan A: Foundation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `ENROOT_STORAGE_BACKEND=zfs` storage driver that replaces `unsquashfs`-per-create with `zfs clone`-per-create, plus a fast `enroot remove` that destroys the dataset (and its template if it has no other clones). Default `dir` backend behavior is preserved byte-for-byte.
+
+**Architecture:** Add a new sourced module `src/storage_zfs.sh` containing all ZFS-specific helpers under a `zfs::` namespace. Branch on `${ENROOT_STORAGE_BACKEND}` in `runtime::create` and `runtime::remove`. Templates live at `${ENROOT_DATA_PATH}/.templates/<sha256>` with snapshot `@pristine`; user clones live at `${ENROOT_DATA_PATH}/<NAME>`. ZFS pool/dataset is admin-provisioned at `${ENROOT_DATA_PATH}` mountpoint.
+
+**Tech Stack:** Bash >= 4.2, OpenZFS, sha256sum, unsquashfs (existing). No new C code, no new build dependencies.
+
+**Project conventions:** No automated tests; verification is manual. Functions are namespaced with `::` (`zfs::ensure_template`). Bash uses `set -euo pipefail; shopt -s lastpipe`. Helpers live in `src/*.sh` and are `source`d, never executed.
+
+**Prerequisite host setup for testing:**
+
+```sh
+sudo zpool create -f tank /dev/loop0          # or any test device
+sudo zfs create -o mountpoint=/srv/enroot tank/enroot
+sudo zfs allow $USER create,mount,clone,destroy,snapshot,rename,readonly tank/enroot
+mkdir -p ~/.config/enroot
+echo 'ENROOT_DATA_PATH /srv/enroot/'$USER >> ~/.config/enroot/.enroot.conf
+echo 'ENROOT_STORAGE_BACKEND zfs' >> ~/.config/enroot/.enroot.conf
+zfs create tank/enroot/$USER
+```
+
+A scratch test image: `enroot import docker://alpine` produces `alpine.sqsh` for use throughout verification.
+
+---
+
+## Files
+
+- **Create:** `src/storage_zfs.sh` — ZFS storage driver (~150 lines).
+- **Modify:** `enroot.in:96` — add `ENROOT_STORAGE_BACKEND` config export.
+- **Modify:** `enroot.in:114` — source `storage_zfs.sh` after `runtime.sh`.
+- **Modify:** `src/runtime.sh:391-430` — branch `runtime::create` on backend.
+- **Modify:** `src/runtime.sh:598-620` — branch `runtime::remove` on backend.
+- **Modify:** `conf/enroot.conf.in` — add commented `#ENROOT_STORAGE_BACKEND dir` line.
+- **Modify:** `Makefile` — add `src/storage_zfs.sh` to `SRCS`.
+
+---
+
+### Task 1: Wire `ENROOT_STORAGE_BACKEND` config knob
+
+**Files:**
+- Modify: `enroot.in:96-103` (config exports section)
+- Modify: `conf/enroot.conf.in:21` (after the `ENROOT_NATIVE_OVERLAYFS` block)
+
+- [ ] **Step 1.1: Add config export to `enroot.in`**
+
+In `enroot.in`, find the block ending around line 100 (`config::export ENROOT_FORCE_OVERRIDE   false`). Add immediately after it:
+
+```bash
+config::export ENROOT_STORAGE_BACKEND  "dir"
+```
+
+Place it before `config::fini` on line 104.
+
+- [ ] **Step 1.2: Add config doc line to `conf/enroot.conf.in`**
+
+After line 22 (the `ENROOT_NATIVE_OVERLAYFS` block), insert:
+
+```
+# Storage backend for the container store. "dir" = today's plain directories (default).
+# "zfs" = use ZFS datasets; ENROOT_DATA_PATH must be a ZFS dataset mountpoint with
+# create/mount/clone/destroy/snapshot delegations granted to the user. See doc/zfs.md.
+#ENROOT_STORAGE_BACKEND     dir
+```
+
+- [ ] **Step 1.3: Verify the config knob plumbs through**
+
+Run:
+
+```sh
+make
+ENROOT_STORAGE_BACKEND=zfs ./enroot info | grep STORAGE
+```
+
+Expected: a line like `ENROOT_STORAGE_BACKEND=zfs` in the output. If it shows `dir`, the config::export call did not land.
+
+- [ ] **Step 1.4: Commit**
+
+```sh
+git add enroot.in conf/enroot.conf.in
+git commit -s -m "Add ENROOT_STORAGE_BACKEND config knob"
+```
+
+---
+
+### Task 2: Create `src/storage_zfs.sh` skeleton
+
+**Files:**
+- Create: `src/storage_zfs.sh`
+- Modify: `enroot.in:114` (source the new file)
+- Modify: `Makefile:29-32` (add to SRCS)
+
+- [ ] **Step 2.1: Create the new module with header and a backend predicate**
+
+Write `src/storage_zfs.sh`:
+
+```bash
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[ -v _STORAGE_ZFS_SH_ ] && return || readonly _STORAGE_ZFS_SH_=1
+
+source "${ENROOT_LIBRARY_PATH}/common.sh"
+
+readonly zfs_template_subdir=".templates"
+readonly zfs_pristine_snap="pristine"
+
+# Returns 0 if the ZFS storage backend is configured, 1 otherwise.
+zfs::enabled() {
+    [ "${ENROOT_STORAGE_BACKEND-dir}" = "zfs" ]
+}
+
+# Resolves and prints the ZFS dataset name backing ${ENROOT_DATA_PATH}.
+# Errors if the path is not a ZFS dataset mountpoint.
+zfs::store_dataset() {
+    local dataset
+    dataset=$(zfs list -H -o name "${ENROOT_DATA_PATH}" 2> /dev/null) || \
+        common::err "ENROOT_DATA_PATH (${ENROOT_DATA_PATH}) is not a ZFS dataset mountpoint"
+    printf "%s" "${dataset}"
+}
+
+# Errors with a clear message if zfs(8) is unavailable or the store is not on ZFS.
+zfs::checkenv() {
+    common::checkcmd zfs sha256sum
+    zfs::store_dataset > /dev/null
+}
+```
+
+- [ ] **Step 2.2: Source it from `enroot.in`**
+
+In `enroot.in`, find the block at line 112-114:
+
+```bash
+source "${ENROOT_LIBRARY_PATH}/common.sh"
+source "${ENROOT_LIBRARY_PATH}/docker.sh"
+source "${ENROOT_LIBRARY_PATH}/runtime.sh"
+```
+
+Add a fourth line after `runtime.sh`:
+
+```bash
+source "${ENROOT_LIBRARY_PATH}/storage_zfs.sh"
+```
+
+- [ ] **Step 2.3: Add to `Makefile` `SRCS` so it ships on install**
+
+In `Makefile` at lines 29-32, change `SRCS` to:
+
+```make
+SRCS := src/common.sh      \
+        src/bundle.sh      \
+        src/docker.sh      \
+        src/runtime.sh     \
+        src/storage_zfs.sh
+```
+
+- [ ] **Step 2.4: Verify it builds and sources clean**
+
+```sh
+make clean && make
+bash -n src/storage_zfs.sh && echo "syntax ok"
+ENROOT_STORAGE_BACKEND=zfs ./enroot version
+```
+
+Expected: build succeeds; `syntax ok` prints; `enroot version` prints the version string without errors.
+
+- [ ] **Step 2.5: Commit**
+
+```sh
+git add src/storage_zfs.sh enroot.in Makefile
+git commit -s -m "Scaffold src/storage_zfs.sh module"
+```
+
+---
+
+### Task 3: Add image-hashing helper
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 3.1: Add `zfs::image_sha256` function**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Computes the sha256 of a squashfs image file. Used as the template cache key.
+zfs::image_sha256() {
+    local -r image="$1"
+    sha256sum "${image}" | awk '{print $1}'
+}
+```
+
+- [ ] **Step 3.2: Verify it produces stable hashes**
+
+```sh
+. ./enroot.in 2>/dev/null  # for source-test purposes only; will exit on bash version check
+# Easier:
+bash -c 'source src/common.sh; source src/storage_zfs.sh; zfs::image_sha256 alpine.sqsh' || true
+sha256sum alpine.sqsh | awk '{print $1}'
+```
+
+Expected: both commands print the same 64-character hex string.
+
+- [ ] **Step 3.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::image_sha256 helper"
+```
+
+---
+
+### Task 4: Add template-ensure helper (atomic extraction)
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 4.1: Add `zfs::ensure_template`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Ensures a template dataset exists for the given image hash, extracting if needed.
+# Prints the template's full dataset name (e.g. tank/enroot/.templates/<sha>).
+# Atomic across concurrent callers via a per-hash .tmp dataset.
+zfs::ensure_template() {
+    local -r image="$1" sha="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r template="${store}/${zfs_template_subdir}/${sha}"
+    local -r tmp="${template}.tmp"
+    local -r snap="${template}@${zfs_pristine_snap}"
+    local -r mountpoint
+    local i timeout=600
+
+    # Fast path: template already exists with @pristine.
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Try to create the .tmp dataset atomically. Whoever wins is the extractor.
+    if zfs create -p "${tmp}" 2> /dev/null; then
+        # We won — extract.
+        mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
+        common::log INFO "Extracting squashfs filesystem into ZFS template..." NL
+        [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
+        unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+                   -user-xattrs -f -d "${mountpoint}" "${image}" >&2
+        common::fixperms "${mountpoint}"
+        zfs rename "${tmp}" "${template}"
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}"
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Lost the race or stale .tmp from a crashed extractor. Wait for @pristine.
+    for ((i = 0; i < timeout; i++)); do
+        if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            printf "%s" "${template}"
+            return
+        fi
+        sleep 1
+    done
+
+    common::err "Timed out waiting for template extraction: ${template}. \
+A previous extractor may have crashed; remove ${tmp} manually and retry."
+}
+```
+
+- [ ] **Step 4.2: Verify with a single extraction**
+
+```sh
+make install DESTDIR=/tmp/enroot prefix=/usr
+export PATH=/tmp/enroot/usr/bin:$PATH
+export ENROOT_LIBRARY_PATH=/tmp/enroot/usr/lib/enroot
+export ENROOT_SYSCONF_PATH=/tmp/enroot/usr/etc/enroot
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         zfs::ensure_template alpine.sqsh $(sha256sum alpine.sqsh | awk "{print \$1}")'
+zfs list -t all | grep templates
+```
+
+Expected: a dataset like `tank/enroot/<USER>/.templates/<sha>` and a `@pristine` snapshot listed by `zfs list -t all`.
+
+- [ ] **Step 4.3: Verify race safety with concurrent extractions**
+
+```sh
+zfs destroy -r tank/enroot/$USER/.templates 2>/dev/null
+for i in 1 2 3 4; do
+    bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+             source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+             zfs::ensure_template alpine.sqsh $(sha256sum alpine.sqsh | awk "{print \$1}")' &
+done
+wait
+zfs list -t all | grep templates
+```
+
+Expected: exactly one template dataset and one `@pristine` snapshot. No `.tmp` left behind. All four background processes exit 0.
+
+- [ ] **Step 4.4: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::ensure_template with atomic extraction"
+```
+
+---
+
+### Task 5: Add clone helper for `create`
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 5.1: Add `zfs::clone_container`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Clones the @pristine snapshot of a template into a named user container.
+# Errors if the target name is already taken.
+zfs::clone_container() {
+    local -r template="$1" name="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+
+    if zfs list -H "${target}" > /dev/null 2>&1; then
+        if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+            common::err "Container already exists: ${name}"
+        fi
+        zfs destroy -r "${target}"
+    fi
+
+    zfs clone "${template}@${zfs_pristine_snap}" "${target}"
+}
+```
+
+- [ ] **Step 5.2: Verify a clone works end-to-end**
+
+```sh
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         sha=$(sha256sum alpine.sqsh | awk "{print \$1}")
+         template=$(zfs::ensure_template alpine.sqsh "${sha}")
+         zfs::clone_container "${template}" alpine_test'
+zfs list | grep alpine_test
+ls /srv/enroot/$USER/alpine_test/etc/os-release
+zfs destroy tank/enroot/$USER/alpine_test  # cleanup
+```
+
+Expected: clone dataset listed; `os-release` readable; cleanup succeeds.
+
+- [ ] **Step 5.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::clone_container helper"
+```
+
+---
+
+### Task 6: Add destroy helper with template refcount
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 6.1: Add `zfs::destroy_container`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Destroys a user container and its template if no other clones reference the
+# template's @pristine snapshot. (Refcount-only behavior; warm-period eviction
+# is added in plan B.)
+zfs::destroy_container() {
+    local -r name="$1"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+    local origin
+
+    if ! zfs list -H "${target}" > /dev/null 2>&1; then
+        common::err "No such container: ${name}"
+    fi
+
+    origin=$(zfs get -H -o value origin "${target}")
+    zfs destroy "${target}"
+
+    # Try to destroy the origin's template if no other clones remain.
+    # 'zfs destroy' on a snapshot with clones fails harmlessly; we attempt and ignore.
+    if [ -n "${origin}" ] && [ "${origin}" != "-" ]; then
+        local template="${origin%@*}"
+        zfs destroy "${origin}" 2> /dev/null && \
+            zfs destroy "${template}" 2> /dev/null || :
+    fi
+}
+```
+
+- [ ] **Step 6.2: Verify single-clone destroy reaps the template**
+
+```sh
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         sha=$(sha256sum alpine.sqsh | awk "{print \$1}")
+         template=$(zfs::ensure_template alpine.sqsh "${sha}")
+         zfs::clone_container "${template}" only
+         zfs::destroy_container only'
+zfs list -t all | grep -c templates
+```
+
+Expected: `0` (template was reaped because it had no other clones).
+
+- [ ] **Step 6.3: Verify multi-clone destroy keeps the template alive**
+
+```sh
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         sha=$(sha256sum alpine.sqsh | awk "{print \$1}")
+         template=$(zfs::ensure_template alpine.sqsh "${sha}")
+         zfs::clone_container "${template}" first
+         zfs::clone_container "${template}" second
+         zfs::destroy_container first'
+zfs list -t all | grep -c templates
+zfs list | grep second
+```
+
+Expected: `1` (template still alive because `second` clone still references it); `second` clone listed. Cleanup: `zfs destroy tank/enroot/$USER/second` (which also reaps the template).
+
+- [ ] **Step 6.4: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::destroy_container with refcount-on-remove"
+```
+
+---
+
+### Task 7: Wire ZFS path into `runtime::create`
+
+**Files:**
+- Modify: `src/runtime.sh:391-430`
+
+- [ ] **Step 7.1: Add backend dispatch at top of `runtime::create`**
+
+In `src/runtime.sh`, replace the body of `runtime::create` (lines 391-430) with:
+
+```bash
+runtime::create() {
+    local image="$1" rootfs="$2"
+
+    # Resolve the container image path.
+    if [ -z "${image}" ]; then
+        common::err "Invalid argument"
+    fi
+    image=$(common::realpath "${image}")
+    if [ ! -f "${image}" ]; then
+        common::err "No such file or directory: ${image}"
+    fi
+    if ! unsquashfs -s "${image}" > /dev/null 2>&1; then
+        common::err "Invalid image format: ${image}"
+    fi
+
+    # Resolve the container rootfs name.
+    if [ -z "${rootfs}" ]; then
+        rootfs=$(basename "${image%.sqsh}")
+    fi
+    if [[ "${rootfs}" == */* ]]; then
+        common::err "Invalid argument: ${rootfs}"
+    fi
+
+    if zfs::enabled; then
+        runtime::_create_zfs "${image}" "${rootfs}"
+    else
+        runtime::_create_dir "${image}" "${rootfs}"
+    fi
+}
+
+runtime::_create_dir() {
+    local -r image="$1" rootfs_name="$2"
+    local rootfs
+
+    common::checkcmd unsquashfs find
+
+    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs_name}")
+    if [ -e "${rootfs}" ]; then
+        if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+            common::err "File already exists: ${rootfs}"
+        else
+            common::rmall "${rootfs}"
+        fi
+    fi
+
+    common::log INFO "Extracting squashfs filesystem..." NL
+    [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
+    unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+               -user-xattrs -d "${rootfs}" "${image}" >&2
+    common::fixperms "${rootfs}"
+}
+
+runtime::_create_zfs() {
+    local -r image="$1" rootfs_name="$2"
+    local sha template
+
+    zfs::checkenv
+    sha=$(zfs::image_sha256 "${image}")
+    template=$(zfs::ensure_template "${image}" "${sha}")
+    zfs::clone_container "${template}" "${rootfs_name}"
+}
+```
+
+- [ ] **Step 7.2: Verify the dir backend still works (no regression)**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+export ENROOT_DATA_PATH=$HOME/.local/share/enroot
+make && make install DESTDIR=/tmp/enroot prefix=/usr
+/tmp/enroot/usr/bin/enroot create -n test_dir alpine.sqsh
+ls $ENROOT_DATA_PATH/test_dir/etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f test_dir
+```
+
+Expected: `os-release` exists; remove succeeds. This is today's behavior unchanged.
+
+- [ ] **Step 7.3: Verify the zfs backend creates a clone**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+/tmp/enroot/usr/bin/enroot create -n test_zfs alpine.sqsh
+zfs list | grep test_zfs
+ls /srv/enroot/$USER/test_zfs/etc/os-release
+```
+
+Expected: clone dataset listed; `os-release` readable.
+
+- [ ] **Step 7.4: Verify second create from same image is fast (clone, not extract)**
+
+```sh
+time /tmp/enroot/usr/bin/enroot create -n test_zfs2 alpine.sqsh
+```
+
+Expected: completes in <1s (vs. multi-second for the first create). No "Extracting squashfs filesystem" log line.
+
+- [ ] **Step 7.5: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Branch runtime::create on ENROOT_STORAGE_BACKEND"
+```
+
+---
+
+### Task 8: Wire ZFS path into `runtime::remove`
+
+**Files:**
+- Modify: `src/runtime.sh:598-620`
+
+- [ ] **Step 8.1: Add backend dispatch in `runtime::remove`**
+
+In `src/runtime.sh`, replace the body of `runtime::remove` (lines 598-620) with:
+
+```bash
+runtime::remove() {
+    local rootfs_name="$1"
+
+    if [ -z "${rootfs_name}" ]; then
+        common::err "Invalid argument"
+    fi
+    if [[ "${rootfs_name}" == */* ]]; then
+        common::err "Invalid argument: ${rootfs_name}"
+    fi
+
+    if zfs::enabled; then
+        runtime::_remove_zfs "${rootfs_name}"
+    else
+        runtime::_remove_dir "${rootfs_name}"
+    fi
+}
+
+runtime::_remove_dir() {
+    local -r rootfs_name="$1"
+    local rootfs
+    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs_name}")
+    if [ ! -d "${rootfs}" ]; then
+        common::err "No such file or directory: ${rootfs}"
+    fi
+    if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+        read -r -e -p "Do you really want to delete ${rootfs}? [y/N] "
+    fi
+    if [ -n "${ENROOT_FORCE_OVERRIDE-}" ] || [ "${REPLY}" = "y" ] || [ "${REPLY}" = "Y" ]; then
+        common::rmall "${rootfs}"
+    fi
+}
+
+runtime::_remove_zfs() {
+    local -r rootfs_name="$1"
+    local rootfs
+    rootfs="${ENROOT_DATA_PATH}/${rootfs_name}"
+    if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+        read -r -e -p "Do you really want to delete ${rootfs}? [y/N] "
+    fi
+    if [ -n "${ENROOT_FORCE_OVERRIDE-}" ] || [ "${REPLY}" = "y" ] || [ "${REPLY}" = "Y" ]; then
+        zfs::destroy_container "${rootfs_name}"
+    fi
+}
+```
+
+- [ ] **Step 8.2: Verify remove on the ZFS backend**
+
+```sh
+zfs list | grep -E "test_zfs|templates"
+/tmp/enroot/usr/bin/enroot remove -f test_zfs
+zfs list | grep test_zfs
+zfs list | grep templates  # should still exist (test_zfs2 still references it)
+/tmp/enroot/usr/bin/enroot remove -f test_zfs2
+zfs list | grep -E "test_zfs|templates"  # both gone
+```
+
+Expected: first remove takes out only the clone; templates list still has the entry. Second remove takes out both the clone and the template.
+
+- [ ] **Step 8.3: Verify dir backend remove still works**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+export ENROOT_DATA_PATH=$HOME/.local/share/enroot
+/tmp/enroot/usr/bin/enroot create -n test_dir alpine.sqsh
+/tmp/enroot/usr/bin/enroot remove -f test_dir
+ls $ENROOT_DATA_PATH/test_dir 2>&1 | grep -q "No such" && echo "ok"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 8.4: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Branch runtime::remove on ENROOT_STORAGE_BACKEND with refcount cleanup"
+```
+
+---
+
+### Task 9: Verify `runtime::list` and `runtime::start` work transparently
+
+**Files:**
+- (Read-only verification — no code changes expected, but confirm.)
+
+- [ ] **Step 9.1: Verify `enroot list` enumerates ZFS clones**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+/tmp/enroot/usr/bin/enroot create -n list_a alpine.sqsh
+/tmp/enroot/usr/bin/enroot create -n list_b alpine.sqsh
+/tmp/enroot/usr/bin/enroot list
+```
+
+Expected: `list_a` and `list_b` listed; the `.templates` directory should NOT appear.
+
+If `.templates` appears, fix `runtime::list` to filter dotfiles. The current `ls -1` in `runtime::list:546` does not show dotfiles by default, so this should work without changes — but verify.
+
+- [ ] **Step 9.2: If `.templates` appears in `enroot list`, filter it**
+
+If verification in 9.1 fails, modify `runtime::list` (`src/runtime.sh:545-548`) to filter the templates subdir:
+
+```bash
+    if [ -z "${fancy}" ]; then
+        ls -1 | grep -v "^\.${zfs_template_subdir##.}\$" || :
+        return
+    fi
+```
+
+(Only apply this if 9.1 actually showed `.templates`. The default `ls -1` already hides dotfiles, so this is a defensive check.)
+
+- [ ] **Step 9.3: Verify `enroot start` against a ZFS clone**
+
+```sh
+/tmp/enroot/usr/bin/enroot start list_a /bin/echo hello
+```
+
+Expected: prints `hello` and exits 0. The clone is mounted as a regular filesystem, so the existing start path should work without modification.
+
+- [ ] **Step 9.4: Cleanup**
+
+```sh
+/tmp/enroot/usr/bin/enroot remove -f list_a list_b
+zfs list -t all | grep -E "list_|templates" || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 9.5: Commit (only if Step 9.2 changed code)**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Filter .templates from enroot list under ZFS backend"
+```
+
+---
+
+### Task 10: Document the foundation and tag a checkpoint
+
+**Files:**
+- Modify: `doc/zfs.md` (status note)
+
+- [ ] **Step 10.1: Mark Plan A status in `doc/zfs.md`**
+
+In `doc/zfs.md`, replace the line near the top that reads:
+
+```
+This document describes an optional ZFS-aware mode for the enroot container store. It is a design proposal — not yet implemented.
+```
+
+with:
+
+```
+This document describes an optional ZFS-aware mode for the enroot container store. As of release X.Y, the foundation (Plan A) is implemented: `enroot create` and `enroot remove` use ZFS datasets when `ENROOT_STORAGE_BACKEND=zfs`. The remaining substitutions (ephemeral start, Docker layer stacking) and the `.zfs`/`zfs://` transports are tracked in subsequent plans.
+```
+
+- [ ] **Step 10.2: End-to-end smoke test**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+/tmp/enroot/usr/bin/enroot create -n smoke alpine.sqsh
+/tmp/enroot/usr/bin/enroot list | grep smoke
+/tmp/enroot/usr/bin/enroot start smoke /bin/cat /etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f smoke
+zfs list -t all | grep -E "smoke|templates" || echo "clean"
+```
+
+Expected: list shows `smoke`; start prints alpine os-release; remove succeeds; final state is clean.
+
+- [ ] **Step 10.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan A (ZFS foundation) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: `ENROOT_STORAGE_BACKEND` knob (T1), backend abstraction (T2-7), ZFS create flow (T4-5,7), refcount-on-remove (T6,8), bundle untouched (no task — bundle code already operates on rootfs directories which a clone presents identically), `enroot list` and `enroot start` transparency verified (T9).
+- [x] Out of scope, deferred to later plans: warm-period eviction (Plan B), `.zfs` file format (Plan C), `zfs://` URI (Plan D), ephemeral-start ZFS substitution (Plan E), Docker layer-stacking (Plan F).
+- [x] No placeholders. Every step has the actual diff or command.
+- [x] Type consistency: function names used in T7-8 (`zfs::enabled`, `zfs::checkenv`, `zfs::image_sha256`, `zfs::ensure_template`, `zfs::clone_container`, `zfs::destroy_container`) all match the definitions in T2-6.
+
+## Known limitations of Plan A
+
+These are deliberate and addressed by later plans:
+
+- **No `.zfs` file support.** Only `.sqsh` is accepted by `enroot create`. (Plan C)
+- **No `zfs://` URI.** Only file-based images. (Plan D)
+- **`enroot start image.sqsh` (ephemeral) still uses squashfuse + overlay** even on the ZFS backend. (Plan E)
+- **`enroot load docker://` still requires `ENROOT_NATIVE_OVERLAYFS=y`** even on the ZFS backend. (Plan F)
+- **No template warm period.** Templates are reaped immediately when the last clone goes away. CI workflows that create+remove+create the same image pay re-extraction cost. (Plan B)
+- **No quota-pressure eviction.** Unbounded template accumulation if WARM_SECONDS were nonzero — moot in Plan A since it's effectively zero. (Plan B)
+
+---
+
+## Execution Handoff
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — execute tasks in this session using `superpowers:executing-plans`, batched checkpoints for review.

--- a/doc/plans/2026-04-29-zfs-b-template-lifecycle.md
+++ b/doc/plans/2026-04-29-zfs-b-template-lifecycle.md
@@ -1,0 +1,514 @@
+# ZFS Backend Plan B: Template Warm/Cold Lifecycle
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Plan A's "destroy template the moment its last clone goes away" with a warm/cold lifecycle. Templates whose refcount hits zero stay around for `ENROOT_TEMPLATE_WARM_SECONDS` (default 7 days), so repeat `create`/`remove` cycles get clone-speed reuse. Cold templates get reaped on every `create`. When the templates dataset crosses `ENROOT_TEMPLATE_PRESSURE_THRESHOLD` (default 0.80) of its quota, warm templates start getting evicted LRU. ENOSPC during extract triggers one retry with all-warm eviction.
+
+**Architecture:** Track `enroot:last_used` (unix epoch) as a ZFS user property on each template. Plug a "sweep" step into `zfs::ensure_template` that runs *before* a new extraction, and a wrapper around the extract/clone path that retries on ENOSPC. Eviction is implicit on `create` only — no daemon, no `enroot gc`.
+
+**Tech Stack:** Same as Plan A. No new tools.
+
+**Depends on:** Plan A landed and on `main`.
+
+**Prerequisite host setup for testing:** Same as Plan A, plus a quota for pressure tests:
+
+```sh
+sudo zfs set quota=200M tank/enroot/$USER/.templates  # tight enough to force pressure
+```
+
+(The `.templates` dataset is created lazily by Plan A's `zfs::ensure_template`. Run one `enroot create` first if it doesn't exist yet, or `zfs create tank/enroot/$USER/.templates` ahead of time.)
+
+---
+
+## Files
+
+- **Modify:** `enroot.in:96-103` — add two new config knobs.
+- **Modify:** `conf/enroot.conf.in` — document the two new knobs.
+- **Modify:** `src/storage_zfs.sh` — extend `zfs::ensure_template`, `zfs::clone_container`, `zfs::destroy_container`; add eviction helpers.
+
+---
+
+### Task 1: Wire the two new config knobs
+
+**Files:**
+- Modify: `enroot.in:103-104` (config exports)
+- Modify: `conf/enroot.conf.in` (after the `ENROOT_STORAGE_BACKEND` block)
+
+- [ ] **Step 1.1: Add the two exports**
+
+In `enroot.in`, immediately after the `config::export ENROOT_STORAGE_BACKEND "dir"` line from Plan A, add:
+
+```bash
+config::export ENROOT_TEMPLATE_WARM_SECONDS    604800
+config::export ENROOT_TEMPLATE_PRESSURE_THRESHOLD 80
+```
+
+(Note: threshold is stored as integer percent, 0-100, to avoid bash floating-point. The 80 = 80%.)
+
+- [ ] **Step 1.2: Document them in `conf/enroot.conf.in`**
+
+After the `ENROOT_STORAGE_BACKEND` block from Plan A, add:
+
+```
+# How long (seconds) a ZFS template with no clones stays evictable only under
+# disk pressure. 0 = evict immediately on remove (refcount-only). Default 7 days.
+#ENROOT_TEMPLATE_WARM_SECONDS    604800
+
+# Quota fraction (0-100) above which routine creates start evicting warm
+# templates LRU until back under. Soft signal; the ZFS quota is the hard wall.
+#ENROOT_TEMPLATE_PRESSURE_THRESHOLD 80
+```
+
+- [ ] **Step 1.3: Verify**
+
+```sh
+make
+ENROOT_STORAGE_BACKEND=zfs ./enroot info | grep -E "WARM|PRESSURE"
+```
+
+Expected: both lines printed.
+
+- [ ] **Step 1.4: Commit**
+
+```sh
+git add enroot.in conf/enroot.conf.in
+git commit -s -m "Add ENROOT_TEMPLATE_WARM_SECONDS and PRESSURE_THRESHOLD knobs"
+```
+
+---
+
+### Task 2: Track `enroot:last_used` on templates
+
+**Files:**
+- Modify: `src/storage_zfs.sh` — extend `zfs::ensure_template` and `zfs::clone_container`.
+
+- [ ] **Step 2.1: Add a helper to update `last_used`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Updates the enroot:last_used user property on a template dataset to now.
+zfs::touch_template() {
+    local -r template="$1"
+    zfs set "enroot:last_used=$(date +%s)" "${template}"
+}
+```
+
+- [ ] **Step 2.2: Have `ensure_template` set `last_used` on extract**
+
+In `src/storage_zfs.sh`, locate the block at the end of the "We won — extract" branch in `zfs::ensure_template`:
+
+```bash
+        zfs rename "${tmp}" "${template}"
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}"
+        printf "%s" "${template}"
+        return
+```
+
+Insert `zfs::touch_template "${template}"` just before `printf`:
+
+```bash
+        zfs rename "${tmp}" "${template}"
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}"
+        zfs::touch_template "${template}"
+        printf "%s" "${template}"
+        return
+```
+
+Also, in the fast-path branch (`if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then`), update the timestamp before printing:
+
+```bash
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        zfs::touch_template "${template}"
+        printf "%s" "${template}"
+        return
+    fi
+```
+
+- [ ] **Step 2.3: Verify timestamps land**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n t1 alpine.sqsh
+zfs get enroot:last_used $(zfs list -H -o name -t filesystem | grep templates | head -1)
+sleep 2
+/tmp/enroot/usr/bin/enroot create -n t2 alpine.sqsh
+zfs get enroot:last_used $(zfs list -H -o name -t filesystem | grep templates | head -1)
+/tmp/enroot/usr/bin/enroot remove -f t1 t2
+```
+
+Expected: timestamp present after first create; updated (later value) after second create.
+
+- [ ] **Step 2.4: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Track enroot:last_used on template extraction and reuse"
+```
+
+---
+
+### Task 3: Decouple `destroy_container` from template destruction
+
+Plan A's `zfs::destroy_container` reaped the template eagerly. Plan B leaves templates around for the warm period; eviction is the sweep's job, not remove's.
+
+**Files:**
+- Modify: `src/storage_zfs.sh:zfs::destroy_container`
+
+- [ ] **Step 3.1: Strip the eager template-destroy from `destroy_container`**
+
+In `src/storage_zfs.sh`, replace the `zfs::destroy_container` body with:
+
+```bash
+zfs::destroy_container() {
+    local -r name="$1"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+
+    if ! zfs list -H "${target}" > /dev/null 2>&1; then
+        common::err "No such container: ${name}"
+    fi
+
+    zfs destroy "${target}"
+    # Template lifecycle is owned by the eviction sweep — see zfs::sweep_templates.
+}
+```
+
+- [ ] **Step 3.2: Verify remove no longer reaps the template**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n only alpine.sqsh
+zfs list -H -o name -t filesystem | grep templates  # save count
+/tmp/enroot/usr/bin/enroot remove -f only
+zfs list -H -o name -t filesystem | grep templates
+```
+
+Expected: template still exists after remove.
+
+- [ ] **Step 3.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Remove eager template destruction from destroy_container"
+```
+
+---
+
+### Task 4: Add eviction-candidate enumeration
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 4.1: Add `zfs::eviction_candidates`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Prints a tab-separated list of evictable templates, sorted by enroot:last_used
+# ascending (oldest first). Each line: "<dataset>\t<last_used_epoch>".
+# A template is evictable iff it has @pristine and that snapshot has no clones.
+zfs::eviction_candidates() {
+    local -r store=$(zfs::store_dataset)
+    local -r templates_dataset="${store}/${zfs_template_subdir}"
+
+    # Bail fast if the templates dataset doesn't exist yet.
+    zfs list -H "${templates_dataset}" > /dev/null 2>&1 || return 0
+
+    # List all template datasets with their last_used and the snapshot's clones property.
+    # Format: <name> <last_used> <clones-of-pristine>
+    zfs list -H -r -d 1 -t filesystem -o name,enroot:last_used "${templates_dataset}" \
+      | awk -v ds="${templates_dataset}" '$1 != ds && $1 != "-" { print $1"\t"$2 }' \
+      | while IFS=$'\t' read -r ds ts; do
+            local clones
+            clones=$(zfs get -H -o value clones "${ds}@${zfs_pristine_snap}" 2> /dev/null) || continue
+            if [ "${clones}" = "-" ] || [ -z "${clones}" ]; then
+                # No clones — eligible.
+                printf "%s\t%s\n" "${ds}" "${ts:--}"
+            fi
+        done \
+      | sort -t $'\t' -k2,2n
+}
+```
+
+- [ ] **Step 4.2: Verify enumeration**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n c1 alpine.sqsh
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         zfs::eviction_candidates'
+# Expected: empty output (template has a clone, so not evictable).
+
+/tmp/enroot/usr/bin/enroot remove -f c1
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         zfs::eviction_candidates'
+# Expected: one line with the template dataset name and its timestamp.
+```
+
+- [ ] **Step 4.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::eviction_candidates enumeration"
+```
+
+---
+
+### Task 5: Add pressure detection
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 5.1: Add `zfs::under_pressure`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Returns 0 if the templates dataset has a quota set and current usage is at or
+# above ENROOT_TEMPLATE_PRESSURE_THRESHOLD percent. Returns 1 otherwise (no quota
+# = no pressure check; under threshold = no pressure).
+zfs::under_pressure() {
+    local -r store=$(zfs::store_dataset)
+    local -r templates_dataset="${store}/${zfs_template_subdir}"
+    local quota used pct
+
+    zfs list -H "${templates_dataset}" > /dev/null 2>&1 || return 1
+
+    quota=$(zfs get -H -p -o value quota "${templates_dataset}")
+    [ "${quota}" = "0" ] || [ "${quota}" = "-" ] && return 1
+
+    used=$(zfs get -H -p -o value used "${templates_dataset}")
+    pct=$(( used * 100 / quota ))
+
+    [ "${pct}" -ge "${ENROOT_TEMPLATE_PRESSURE_THRESHOLD-80}" ]
+}
+```
+
+- [ ] **Step 5.2: Verify**
+
+```sh
+zfs set quota=200M tank/enroot/$USER/.templates
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         zfs::under_pressure && echo "pressure" || echo "no pressure"'
+```
+
+Expected: depends on current usage. With a fresh test setup and one template, "no pressure". To force pressure, lower the quota: `zfs set quota=10M ...` then re-run; expect "pressure".
+
+- [ ] **Step 5.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::under_pressure quota-fraction check"
+```
+
+---
+
+### Task 6: Add eviction sweep
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 6.1: Add `zfs::sweep_templates`**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Sweeps evictable templates. Always reaps cold ones (last_used older than
+# ENROOT_TEMPLATE_WARM_SECONDS); also reaps warm ones LRU when under pressure,
+# stopping once back under threshold. With ENROOT_TEMPLATE_WARM_SECONDS=0 and
+# no quota, this collapses to "reap any template with no clones".
+zfs::sweep_templates() {
+    local now warm_secs pressure
+    now=$(date +%s)
+    warm_secs="${ENROOT_TEMPLATE_WARM_SECONDS-604800}"
+    zfs::under_pressure && pressure=y || pressure=
+
+    zfs::eviction_candidates | while IFS=$'\t' read -r ds ts; do
+        local age is_warm
+        if [ "${ts}" = "-" ] || [ -z "${ts}" ]; then
+            age=$((warm_secs + 1))   # missing timestamp = treat as cold
+        else
+            age=$(( now - ts ))
+        fi
+
+        if [ "${age}" -lt "${warm_secs}" ] && [ -z "${pressure}" ]; then
+            continue                 # warm and no pressure: keep
+        fi
+
+        common::log INFO "Evicting template ${ds##*/} (age ${age}s)"
+        zfs destroy "${ds}@${zfs_pristine_snap}" 2> /dev/null && \
+            zfs destroy "${ds}" 2> /dev/null || :
+
+        if [ -n "${pressure}" ]; then
+            zfs::under_pressure || break    # back under — stop
+        fi
+    done
+}
+```
+
+- [ ] **Step 6.2: Wire it into `zfs::ensure_template`**
+
+In `src/storage_zfs.sh`, at the very top of `zfs::ensure_template`, before the fast-path snapshot check, add:
+
+```bash
+zfs::ensure_template() {
+    local -r image="$1" sha="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r template="${store}/${zfs_template_subdir}/${sha}"
+    local -r tmp="${template}.tmp"
+    local -r snap="${template}@${zfs_pristine_snap}"
+    local mountpoint
+    local i timeout=600
+
+    zfs::sweep_templates
+
+    # Fast path: ...
+    ...
+}
+```
+
+- [ ] **Step 6.3: Verify cold eviction**
+
+```sh
+export ENROOT_TEMPLATE_WARM_SECONDS=2
+/tmp/enroot/usr/bin/enroot create -n a alpine.sqsh
+/tmp/enroot/usr/bin/enroot remove -f a
+sleep 3
+zfs list -H -o name -t filesystem | grep templates    # should still exist
+/tmp/enroot/usr/bin/enroot create -n b alpine.sqsh    # triggers sweep, then re-extracts
+zfs list -H -o name -t filesystem | grep templates    # exists (the new one)
+/tmp/enroot/usr/bin/enroot remove -f b
+unset ENROOT_TEMPLATE_WARM_SECONDS
+```
+
+Expected: after the sleep, `create -n b` logs "Evicting template ..." for the old one before extracting fresh.
+
+- [ ] **Step 6.4: Verify warm preservation**
+
+```sh
+export ENROOT_TEMPLATE_WARM_SECONDS=3600
+/tmp/enroot/usr/bin/enroot create -n a alpine.sqsh
+/tmp/enroot/usr/bin/enroot remove -f a
+/tmp/enroot/usr/bin/enroot create -n b alpine.sqsh    # should be fast — clone, not extract
+```
+
+Expected: the second create should NOT log "Extracting squashfs filesystem" (template was warm and reused). Cleanup: `enroot remove -f b`.
+
+- [ ] **Step 6.5: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::sweep_templates eviction with warm/cold/pressure logic"
+```
+
+---
+
+### Task 7: ENOSPC retry path
+
+**Files:**
+- Modify: `src/storage_zfs.sh:zfs::ensure_template` (extraction block)
+
+- [ ] **Step 7.1: Add a retry around the extraction**
+
+In `zfs::ensure_template`, wrap the extraction in a retry that escalates eviction to all-warm on ENOSPC:
+
+Replace this block:
+
+```bash
+        common::log INFO "Extracting squashfs filesystem into ZFS template..." NL
+        [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
+        unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+                   -user-xattrs -f -d "${mountpoint}" "${image}" >&2
+        common::fixperms "${mountpoint}"
+```
+
+with:
+
+```bash
+        common::log INFO "Extracting squashfs filesystem into ZFS template..." NL
+        [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
+        if ! unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+                        -user-xattrs -f -d "${mountpoint}" "${image}" >&2; then
+            # Could be ENOSPC or any other failure. Force a warm-aggressive sweep and retry once.
+            common::log WARN "Extraction failed; evicting all warm templates and retrying"
+            ENROOT_TEMPLATE_WARM_SECONDS=0 zfs::sweep_templates
+            unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+                       -user-xattrs -f -d "${mountpoint}" "${image}" >&2 \
+              || common::err "Extraction failed even after evicting warm templates"
+        fi
+        common::fixperms "${mountpoint}"
+```
+
+- [ ] **Step 7.2: Verify retry under tight quota**
+
+```sh
+zfs set quota=10M tank/enroot/$USER/.templates    # too tight for alpine extraction (~5M)
+/tmp/enroot/usr/bin/enroot create -n big1 alpine.sqsh
+/tmp/enroot/usr/bin/enroot remove -f big1
+zfs set quota=10M tank/enroot/$USER/.templates    # still tight; old template now warm
+/tmp/enroot/usr/bin/enroot create -n big2 alpine.sqsh   # should log "Extraction failed; evicting all warm" and succeed
+zfs set quota=200M tank/enroot/$USER/.templates    # restore
+/tmp/enroot/usr/bin/enroot remove -f big2
+```
+
+Expected: second create succeeds after eviction; final state has only the new template.
+
+- [ ] **Step 7.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add ENOSPC retry with warm-aggressive sweep"
+```
+
+---
+
+### Task 8: Document Plan B as implemented
+
+**Files:**
+- Modify: `doc/zfs.md`
+
+- [ ] **Step 8.1: Update status note**
+
+Update the status sentence near the top of `doc/zfs.md` to mention Plan B is now landed (the warm-period and pressure-eviction logic).
+
+- [ ] **Step 8.2: End-to-end smoke**
+
+```sh
+export ENROOT_TEMPLATE_WARM_SECONDS=600
+zfs set quota=200M tank/enroot/$USER/.templates
+for i in 1 2 3; do
+    /tmp/enroot/usr/bin/enroot create -n smoke_$i alpine.sqsh
+    /tmp/enroot/usr/bin/enroot remove -f smoke_$i
+done
+zfs list -t all -r tank/enroot/$USER/.templates | head
+# Expected: still one template (warm, reused across all three cycles).
+
+ENROOT_TEMPLATE_WARM_SECONDS=0 /tmp/enroot/usr/bin/enroot create -n smoke_x alpine.sqsh
+/tmp/enroot/usr/bin/enroot remove -f smoke_x
+ENROOT_TEMPLATE_WARM_SECONDS=0 /tmp/enroot/usr/bin/enroot create -n smoke_y alpine.sqsh
+zfs list -t all -r tank/enroot/$USER/.templates | wc -l
+# Expected: just one again — old one was evicted by the WARM=0 sweep, replaced by new.
+/tmp/enroot/usr/bin/enroot remove -f smoke_y
+```
+
+- [ ] **Step 8.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan B (template warm/cold lifecycle) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: warm-period (T2,T6), pressure threshold (T5,T6), routine cold sweep on every create (T6), ENOSPC retry (T7), `WARM_SECONDS=0` collapse to refcount-only (T6 — pressure-flag handling and warm_secs=0 means age >= warm_secs always, evict immediately).
+- [x] Type consistency: `zfs::touch_template`, `zfs::eviction_candidates`, `zfs::under_pressure`, `zfs::sweep_templates` are defined in T2/T4/T5/T6 and only called from each other and `zfs::ensure_template`.
+- [x] No placeholders.
+
+## Execution Handoff
+
+Same options as Plan A.

--- a/doc/plans/2026-04-29-zfs-c-zfs-format.md
+++ b/doc/plans/2026-04-29-zfs-c-zfs-format.md
@@ -1,0 +1,418 @@
+# ZFS Backend Plan C: `.zfs` Image Format
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `.zfs` (zfs send stream) as a second image format alongside `.sqsh`. `enroot create foo.zfs` materializes the stream into the template cache via `zfs recv`, then clones to the user's container — semantically identical to `.sqsh` once the cache is populated, just with a different materialization step. `enroot export NAME --format=zfs` produces a `.zfs` file from a clone's `@pristine` snapshot. Hard error on a non-ZFS host. No magic-byte sniffing — extension is the contract.
+
+**Architecture:** Dispatch on file extension at the entry point of `runtime::create` and `runtime::export`. Add a sibling to `zfs::ensure_template` that runs `zfs recv` instead of `unsquashfs`. Add a `zfs::send_stream` helper for export.
+
+**Depends on:** Plan A.
+
+**Prerequisite host setup:** Same as Plan A.
+
+---
+
+## Files
+
+- **Modify:** `src/runtime.sh:391-...` (`runtime::create`) — extension-based dispatch.
+- **Modify:** `src/runtime.sh:492-...` (`runtime::export`) — `--format=zfs` support.
+- **Modify:** `src/storage_zfs.sh` — add `zfs::ensure_template_from_stream`, `zfs::send_stream`.
+- **Modify:** `enroot.in:442-477` (`enroot::export`) — add `--format` flag.
+- **Modify:** `enroot.in:127-137` (export usage string) — document `--format`.
+
+---
+
+### Task 1: Add `zfs::ensure_template_from_stream`
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 1.1: Add the function**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Materializes a template by zfs-receiving a stream file. The cache key is the
+# sha256 of the stream file (same scheme as the .sqsh path). Atomic via .tmp
+# dataset; integrates with the same eviction sweep as ensure_template.
+zfs::ensure_template_from_stream() {
+    local -r stream="$1" sha="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r template="${store}/${zfs_template_subdir}/${sha}"
+    local -r tmp="${template}.tmp"
+    local -r snap="${template}@${zfs_pristine_snap}"
+    local i timeout=600
+
+    zfs::sweep_templates 2> /dev/null || :    # no-op if Plan B not landed
+
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        zfs::touch_template "${template}" 2> /dev/null || :
+        printf "%s" "${template}"
+        return
+    fi
+
+    if zfs create -p "$(dirname "${tmp}")" 2> /dev/null; then : ; fi   # parent
+    # zfs recv into the .tmp name; on success, rename to final.
+    if zfs receive -F "${tmp}" < "${stream}" 2> /dev/null; then
+        # The received stream brings its own snapshot; rename the dataset and
+        # alias the snapshot to @pristine if necessary.
+        zfs rename "${tmp}" "${template}"
+        if ! zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            local recvd_snap
+            recvd_snap=$(zfs list -H -t snapshot -o name -r -d 1 "${template}" | head -1)
+            [ -n "${recvd_snap}" ] && zfs rename "${recvd_snap}" "${snap}"
+        fi
+        zfs set readonly=on "${template}"
+        zfs::touch_template "${template}" 2> /dev/null || :
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Receive failed — clean up our .tmp if any, then wait for another writer.
+    zfs destroy -r "${tmp}" 2> /dev/null || :
+
+    for ((i = 0; i < timeout; i++)); do
+        if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            printf "%s" "${template}"
+            return
+        fi
+        sleep 1
+    done
+    common::err "Timed out waiting for stream receive: ${template}"
+}
+```
+
+- [ ] **Step 1.2: Add `zfs::send_stream` for the export side**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Sends a clone's @pristine snapshot (or the template it was cloned from) as a
+# full zfs-send stream to a file. Container must exist and be a ZFS clone.
+zfs::send_stream() {
+    local -r name="$1" filename="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+    local origin
+
+    if ! zfs list -H "${target}" > /dev/null 2>&1; then
+        common::err "No such container: ${name}"
+    fi
+
+    origin=$(zfs get -H -o value origin "${target}")
+    if [ -z "${origin}" ] || [ "${origin}" = "-" ]; then
+        # Not a clone — must take a fresh snapshot of the live dataset.
+        local snap="${target}@enroot-export-$$"
+        zfs snapshot "${snap}"
+        zfs send "${snap}" > "${filename}"
+        zfs destroy "${snap}"
+    else
+        zfs send "${origin}" > "${filename}"
+    fi
+}
+```
+
+- [ ] **Step 1.3: Verify the recv side standalone**
+
+```sh
+# Manually create a stream file from an existing template:
+zfs send tank/enroot/$USER/.templates/<some-sha>@pristine > /tmp/test.zfs
+# Now feed it back in:
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         sha=$(sha256sum /tmp/test.zfs | awk "{print \$1}")
+         zfs::ensure_template_from_stream /tmp/test.zfs "${sha}"'
+zfs list -t all | grep "${sha:0:12}"
+```
+
+Expected: a template dataset and `@pristine` snapshot whose name contains the stream's sha.
+
+- [ ] **Step 1.4: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::ensure_template_from_stream and zfs::send_stream"
+```
+
+---
+
+### Task 2: Dispatch `runtime::create` on file extension
+
+**Files:**
+- Modify: `src/runtime.sh:391-430` (Plan A's `runtime::create`)
+
+- [ ] **Step 2.1: Replace the body of `runtime::create` to dispatch on extension**
+
+In `src/runtime.sh`, change `runtime::create` to:
+
+```bash
+runtime::create() {
+    local image="$1" rootfs="$2"
+
+    if [ -z "${image}" ]; then
+        common::err "Invalid argument"
+    fi
+    image=$(common::realpath "${image}")
+    if [ ! -f "${image}" ]; then
+        common::err "No such file or directory: ${image}"
+    fi
+
+    case "${image}" in
+        *.zfs)
+            if ! zfs::enabled; then
+                common::err ".zfs images require ENROOT_STORAGE_BACKEND=zfs"
+            fi
+            if [ -z "${rootfs}" ]; then
+                rootfs=$(basename "${image%.zfs}")
+            fi
+            if [[ "${rootfs}" == */* ]]; then
+                common::err "Invalid argument: ${rootfs}"
+            fi
+            zfs::checkenv
+            local sha template
+            sha=$(zfs::image_sha256 "${image}")
+            template=$(zfs::ensure_template_from_stream "${image}" "${sha}")
+            zfs::clone_container "${template}" "${rootfs}"
+            ;;
+        *)
+            if ! unsquashfs -s "${image}" > /dev/null 2>&1; then
+                common::err "Invalid image format: ${image} (expected .sqsh or .zfs)"
+            fi
+            if [ -z "${rootfs}" ]; then
+                rootfs=$(basename "${image%.sqsh}")
+            fi
+            if [[ "${rootfs}" == */* ]]; then
+                common::err "Invalid argument: ${rootfs}"
+            fi
+            if zfs::enabled; then
+                runtime::_create_zfs "${image}" "${rootfs}"
+            else
+                runtime::_create_dir "${image}" "${rootfs}"
+            fi
+            ;;
+    esac
+}
+```
+
+- [ ] **Step 2.2: Verify `.zfs` create end-to-end**
+
+```sh
+# Round-trip via a stream:
+/tmp/enroot/usr/bin/enroot create -n donor alpine.sqsh
+zfs send tank/enroot/$USER/.templates/$(ls /srv/enroot/$USER/.templates)@pristine > /tmp/alpine.zfs
+/tmp/enroot/usr/bin/enroot remove -f donor
+zfs destroy -r tank/enroot/$USER/.templates    # nuke cache to force recv
+/tmp/enroot/usr/bin/enroot create -n viareceive /tmp/alpine.zfs
+ls /srv/enroot/$USER/viareceive/etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f viareceive
+```
+
+Expected: `os-release` readable; this exercised the `.zfs` recv path.
+
+- [ ] **Step 2.3: Verify hard error on non-ZFS backend**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+/tmp/enroot/usr/bin/enroot create -n bad /tmp/alpine.zfs && echo BAD || echo OK
+```
+
+Expected: `OK` (command failed with the "ENROOT_STORAGE_BACKEND=zfs" error message).
+
+- [ ] **Step 2.4: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Dispatch runtime::create on .sqsh vs .zfs extension"
+```
+
+---
+
+### Task 3: Add `--format` to `enroot::export` and `runtime::export`
+
+**Files:**
+- Modify: `enroot.in:442-477` (CLI parsing)
+- Modify: `enroot.in:163-172` (usage string for export)
+- Modify: `src/runtime.sh:492-536` (`runtime::export`)
+
+- [ ] **Step 3.1: Update the export usage block**
+
+In `enroot.in:163-172`, add a `--format` row to the options:
+
+```
+   -o, --output  Name of the output image file (defaults to "NAME.sqsh" or "NAME.zfs")
+   -f, --force   Overwrite an existing image
+       --format  Output format: "sqsh" (default) or "zfs"
+```
+
+- [ ] **Step 3.2: Add `--format` parsing in `enroot::export`**
+
+In `enroot.in:442-477`, add a `--format`/`--format=` case to the option parser, alongside the existing `-o` / `-f` cases. Pass the format through to `runtime::export` as a new third positional argument.
+
+Concretely, change:
+
+```bash
+    runtime::export "${name}" "${filename}"
+```
+
+to:
+
+```bash
+    runtime::export "${name}" "${filename}" "${format:-sqsh}"
+```
+
+and ensure `format=` defaults to empty in the local declarations and is set by the parser when the flag is given.
+
+- [ ] **Step 3.3: Branch `runtime::export` on format**
+
+In `src/runtime.sh`, replace `runtime::export` (lines 492-536) with:
+
+```bash
+runtime::export() {
+    local rootfs="$1" filename="$2" format="${3:-sqsh}"
+    local exclude=()
+
+    if [ -z "${rootfs}" ]; then
+        common::err "Invalid argument"
+    fi
+    if [[ "${rootfs}" == */* ]]; then
+        common::err "Invalid argument: ${rootfs}"
+    fi
+
+    case "${format}" in
+        sqsh) ;;
+        zfs)
+            if ! zfs::enabled; then
+                common::err "--format=zfs requires ENROOT_STORAGE_BACKEND=zfs"
+            fi
+            ;;
+        *) common::err "Invalid format: ${format}" ;;
+    esac
+
+    if [ "${format}" = "sqsh" ]; then
+        common::checkcmd mksquashfs
+        local rootfs_path
+        rootfs_path=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs}")
+        if [ ! -d "${rootfs_path}" ]; then
+            common::err "No such file or directory: ${rootfs_path}"
+        fi
+        if [ -z "${filename}" ]; then
+            filename="$(basename "${rootfs_path}").sqsh"
+        fi
+        filename=$(common::realpath "${filename}")
+        if [ -e "${filename}" ]; then
+            if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+                common::err "File already exists: ${filename}"
+            else
+                rm -f "${filename}"
+            fi
+        fi
+        find "${rootfs_path}" -path "${rootfs_path}/dev/*" -o -perm 0000 -prune \( -empty -o -type d \) | readarray -t exclude
+        if [ -d "${rootfs_path}${bundle_dir}" ]; then
+            exclude+=("${rootfs_path}${bundle_dir}")
+        fi
+        if [ -f "${rootfs_path}${lock_file}" ]; then
+            exclude+=("${rootfs_path}${lock_file}")
+        fi
+        common::log INFO "Creating squashfs filesystem..." NL
+        mksquashfs "${rootfs_path}" "${filename}" -all-root ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+            ${ENROOT_SQUASH_OPTIONS} ${exclude[@]+-e "${exclude[@]}"} >&2
+    else
+        if [ -z "${filename}" ]; then
+            filename="${rootfs}.zfs"
+        fi
+        filename=$(common::realpath "${filename}")
+        if [ -e "${filename}" ]; then
+            if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+                common::err "File already exists: ${filename}"
+            else
+                rm -f "${filename}"
+            fi
+        fi
+        common::log INFO "Creating zfs send stream..." NL
+        zfs::send_stream "${rootfs}" "${filename}"
+    fi
+}
+```
+
+- [ ] **Step 3.4: Verify `.sqsh` export still works (no regression)**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+export ENROOT_DATA_PATH=$HOME/.local/share/enroot
+/tmp/enroot/usr/bin/enroot create -n exp_test alpine.sqsh
+/tmp/enroot/usr/bin/enroot export -o /tmp/regress.sqsh exp_test
+unsquashfs -s /tmp/regress.sqsh > /dev/null && echo OK
+/tmp/enroot/usr/bin/enroot remove -f exp_test
+rm /tmp/regress.sqsh
+```
+
+Expected: `OK`.
+
+- [ ] **Step 3.5: Verify `.zfs` export**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+/tmp/enroot/usr/bin/enroot create -n exp_zfs alpine.sqsh
+/tmp/enroot/usr/bin/enroot export --format=zfs -o /tmp/exp.zfs exp_zfs
+file /tmp/exp.zfs   # should mention "ZFS"
+/tmp/enroot/usr/bin/enroot create -n round_trip /tmp/exp.zfs
+ls /srv/enroot/$USER/round_trip/etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f exp_zfs round_trip
+```
+
+Expected: file produced, round-trip create succeeds, os-release readable.
+
+- [ ] **Step 3.6: Commit**
+
+```sh
+git add enroot.in src/runtime.sh
+git commit -s -m "Add --format=zfs to enroot export"
+```
+
+---
+
+### Task 4: Document Plan C as implemented
+
+**Files:**
+- Modify: `doc/zfs.md`
+
+- [ ] **Step 4.1: Update status note**
+
+Update `doc/zfs.md` to mark Plan C (`.zfs` file format) as landed.
+
+- [ ] **Step 4.2: End-to-end smoke**
+
+```sh
+# Round-trip and bundle integrity:
+/tmp/enroot/usr/bin/enroot create -n smoke alpine.sqsh
+/tmp/enroot/usr/bin/enroot export --format=zfs smoke
+/tmp/enroot/usr/bin/enroot export -o smoke.sqsh smoke           # sqsh export still works
+/tmp/enroot/usr/bin/enroot remove -f smoke
+/tmp/enroot/usr/bin/enroot create -n from_zfs smoke.zfs
+/tmp/enroot/usr/bin/enroot create -n from_sqsh smoke.sqsh
+diff <(ls /srv/enroot/$USER/from_zfs/etc) <(ls /srv/enroot/$USER/from_sqsh/etc) && echo SAME
+/tmp/enroot/usr/bin/enroot remove -f from_zfs from_sqsh
+rm smoke.zfs smoke.sqsh
+```
+
+Expected: `SAME` — both formats produce equivalent rootfs contents.
+
+- [ ] **Step 4.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan C (.zfs format) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: `enroot create foo.zfs` (T2), `enroot export --format=zfs` (T3), hard error on non-ZFS host (T2.3, T3.3), no magic-byte sniffing — extension-only dispatch (T2.1).
+- [x] Type consistency: `zfs::ensure_template_from_stream`, `zfs::send_stream` in T1 are referenced by T2, T3.
+- [x] No placeholders.
+
+## Execution Handoff
+
+Same options as Plan A.

--- a/doc/plans/2026-04-29-zfs-d-zfs-uri.md
+++ b/doc/plans/2026-04-29-zfs-d-zfs-uri.md
@@ -1,0 +1,496 @@
+# ZFS Backend Plan D: `zfs://` URI Transport
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `zfs://host/NAME` URI scheme for `enroot load` and `enroot export`. Wire transport is `ssh host enroot ...` invoking `enroot export --zfs-send` / `enroot import --zfs-recv` on the remote. The remote pool name and dataset paths never leak across the wire — the URI names a *container on a remote enroot host*. `enroot import zfs://...` is rejected (use `load` — there is no portable file artifact to produce). No incremental sends in v1; full streams only.
+
+**Architecture:** Two new internal flags `--zfs-send` and `--zfs-recv` on `enroot export` and `enroot import` (respectively) that read/write a stream on stdout/stdin. The `zfs://` URI handler in `runtime::load` and `runtime::export` shells out to `ssh` and pipes streams.
+
+**Depends on:** Plan A and Plan C.
+
+**Prerequisite host setup:** Two ZFS-enabled hosts (or loopback ssh on one host) with passwordless SSH between them; `zfs allow` granted on both for the test user as in Plan A.
+
+---
+
+## Files
+
+- **Modify:** `enroot.in:352-394` (`enroot::import`) — add `--zfs-recv` internal flag, reject `zfs://`.
+- **Modify:** `enroot.in:395-441` (`enroot::load`) — accept `zfs://`.
+- **Modify:** `enroot.in:442-477` (`enroot::export`) — add `--zfs-send` internal flag, accept `zfs://` destination.
+- **Modify:** `src/runtime.sh:450-490` (`runtime::import`/`runtime::load`) — dispatch `zfs://`.
+- **Modify:** `src/runtime.sh:492-...` (`runtime::export`) — accept `zfs://` destination.
+- **Modify:** `src/storage_zfs.sh` — `zfs::pull_via_ssh`, `zfs::push_via_ssh`, `zfs::recv_to_template_stdin`, `zfs::send_clone_stdout`.
+
+---
+
+### Task 1: Add `zfs::recv_to_template_stdin` and `zfs::send_clone_stdout`
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 1.1: Add stdin/stdout siblings of the file-based helpers**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Receives a zfs send stream from stdin into the template cache.
+# The cache key is provided by the caller (since we cannot easily hash a stream
+# we are reading once); for SSH transport the remote enroot computes a content
+# hash and passes it via env ENROOT_REMOTE_TEMPLATE_KEY. If unset, we generate a
+# transient cache key from the stream's first snapshot guid.
+zfs::recv_to_template_stdin() {
+    local key="${ENROOT_REMOTE_TEMPLATE_KEY-}"
+    local -r store=$(zfs::store_dataset)
+    local tmp template snap
+
+    if [ -z "${key}" ]; then
+        # Buffer to a temp file so we can hash and replay.
+        local buf
+        buf=$(mktemp -p "${ENROOT_TEMP_PATH:-/tmp}" enroot-recv.XXXXXX)
+        trap "rm -f '${buf}'" RETURN
+        cat > "${buf}"
+        key=$(sha256sum "${buf}" | awk '{print $1}')
+        zfs::ensure_template_from_stream "${buf}" "${key}"
+    else
+        tmp="${store}/${zfs_template_subdir}/${key}.tmp"
+        template="${store}/${zfs_template_subdir}/${key}"
+        snap="${template}@${zfs_pristine_snap}"
+
+        if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            # Already cached — drain stdin and return.
+            cat > /dev/null
+            zfs::touch_template "${template}" 2> /dev/null || :
+            printf "%s" "${template}"
+            return
+        fi
+
+        zfs receive -F "${tmp}"
+        zfs rename "${tmp}" "${template}"
+        if ! zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            local recvd_snap
+            recvd_snap=$(zfs list -H -t snapshot -o name -r -d 1 "${template}" | head -1)
+            [ -n "${recvd_snap}" ] && zfs rename "${recvd_snap}" "${snap}"
+        fi
+        zfs set readonly=on "${template}"
+        zfs::touch_template "${template}" 2> /dev/null || :
+        printf "%s" "${template}"
+    fi
+}
+
+# Sends a clone's @pristine snapshot (or a fresh snapshot if the container is not
+# a clone) to stdout. Used by --zfs-send.
+zfs::send_clone_stdout() {
+    local -r name="$1"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+    local origin
+
+    if ! zfs list -H "${target}" > /dev/null 2>&1; then
+        common::err "No such container: ${name}"
+    fi
+
+    origin=$(zfs get -H -o value origin "${target}")
+    if [ -z "${origin}" ] || [ "${origin}" = "-" ]; then
+        local snap="${target}@enroot-export-$$"
+        zfs snapshot "${snap}"
+        trap "zfs destroy '${snap}' 2> /dev/null" RETURN
+        zfs send "${snap}"
+    else
+        zfs send "${origin}"
+    fi
+}
+```
+
+- [ ] **Step 1.2: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::recv_to_template_stdin and zfs::send_clone_stdout helpers"
+```
+
+---
+
+### Task 2: Add `--zfs-send` to `enroot export`
+
+**Files:**
+- Modify: `enroot.in:442-477` (`enroot::export`)
+- Modify: `src/runtime.sh` `runtime::export` (extend Plan C dispatch)
+
+- [ ] **Step 2.1: Add `--zfs-send` parser case**
+
+In `enroot.in` `enroot::export`, add a `--zfs-send` flag that, when present, reads the container name from the next positional and pipes the stream to stdout. This is an internal flag; not documented in the user-visible usage.
+
+Add to the option parser:
+
+```bash
+        --zfs-send)
+            zfs_send=y
+            shift
+            ;;
+```
+
+After the parser, before the existing `runtime::export` call:
+
+```bash
+    if [ -n "${zfs_send-}" ]; then
+        if ! zfs::enabled; then
+            common::err "--zfs-send requires ENROOT_STORAGE_BACKEND=zfs"
+        fi
+        zfs::send_clone_stdout "${name}"
+        return
+    fi
+```
+
+(`name` here is the same positional argument the existing `enroot::export` already parses.)
+
+- [ ] **Step 2.2: Verify locally**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n send_test alpine.sqsh
+/tmp/enroot/usr/bin/enroot export --zfs-send send_test > /tmp/sendtest.zfs
+file /tmp/sendtest.zfs                     # should mention ZFS / data
+/tmp/enroot/usr/bin/enroot remove -f send_test
+```
+
+Expected: file produced, no console errors, file is non-empty and looks like a zfs stream.
+
+- [ ] **Step 2.3: Commit**
+
+```sh
+git add enroot.in
+git commit -s -m "Add internal --zfs-send flag to enroot export"
+```
+
+---
+
+### Task 3: Add `--zfs-recv` to `enroot import`
+
+**Files:**
+- Modify: `enroot.in:352-394` (`enroot::import`)
+
+- [ ] **Step 3.1: Add `--zfs-recv` parser case**
+
+The semantics: `enroot import --zfs-recv -n NAME` reads a stream from stdin, materializes it as a template via `zfs::recv_to_template_stdin`, and clones to `NAME`.
+
+In `enroot::import`, add to the option parser:
+
+```bash
+        --zfs-recv)
+            zfs_recv=y
+            shift
+            ;;
+        -n|--name)
+            [ -z "${2-}" ] && enroot::usage import 1
+            name="$2"
+            shift 2
+            ;;
+```
+
+After the parser, *before* the existing positional URI dispatch:
+
+```bash
+    if [ -n "${zfs_recv-}" ]; then
+        if ! zfs::enabled; then
+            common::err "--zfs-recv requires ENROOT_STORAGE_BACKEND=zfs"
+        fi
+        if [ -z "${name-}" ]; then
+            common::err "--zfs-recv requires -n NAME"
+        fi
+        local template
+        template=$(zfs::recv_to_template_stdin)
+        zfs::clone_container "${template}" "${name}"
+        return
+    fi
+```
+
+(Add `name=` to the locals at the top of `enroot::import` if it is not already declared.)
+
+- [ ] **Step 3.2: Verify with a local pipe**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n recv_donor alpine.sqsh
+/tmp/enroot/usr/bin/enroot export --zfs-send recv_donor \
+  | /tmp/enroot/usr/bin/enroot import --zfs-recv -n recv_target
+ls /srv/enroot/$USER/recv_target/etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f recv_donor recv_target
+```
+
+Expected: `os-release` readable; the pipe round-trip works.
+
+- [ ] **Step 3.3: Commit**
+
+```sh
+git add enroot.in
+git commit -s -m "Add internal --zfs-recv flag to enroot import"
+```
+
+---
+
+### Task 4: Add `zfs://` URI parser and dispatch
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 4.1: Add a parser**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Parses a zfs:// URI into "host\tname". Format: zfs://host/NAME (NAME may
+# contain extra path components which are reassembled into the container name).
+zfs::parse_uri() {
+    local -r uri="$1"
+    if [[ ! "${uri}" =~ ^zfs://([^/]+)/(.+)$ ]]; then
+        common::err "Invalid zfs:// URI: ${uri}"
+    fi
+    printf "%s\t%s" "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+}
+```
+
+- [ ] **Step 4.2: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::parse_uri"
+```
+
+---
+
+### Task 5: Wire `zfs://` into `runtime::load`
+
+**Files:**
+- Modify: `src/runtime.sh:470-490` (`runtime::load`)
+
+- [ ] **Step 5.1: Add `zfs://` case to `runtime::load`**
+
+In `src/runtime.sh:484-489`, change:
+
+```bash
+    case "${uri}" in
+    docker://*)
+        docker::load "${uri}" "${rootfs}" "${arch}" ;;
+    *)
+        common::err "Invalid argument: ${uri}" ;;
+    esac
+```
+
+to:
+
+```bash
+    case "${uri}" in
+    docker://*)
+        docker::load "${uri}" "${rootfs}" "${arch}" ;;
+    zfs://*)
+        if ! zfs::enabled; then
+            common::err "zfs:// URIs require ENROOT_STORAGE_BACKEND=zfs"
+        fi
+        local host remote_name template
+        zfs::parse_uri "${uri}" \
+          | { common::read -r host; common::read -r remote_name; }
+        [ -z "${rootfs}" ] && rootfs="${remote_name##*/}"
+        common::log INFO "Pulling ${remote_name} from ${host} via ssh"
+        ssh "${host}" enroot export --zfs-send "${remote_name}" \
+          | { template=$(zfs::recv_to_template_stdin); zfs::clone_container "${template}" "${rootfs}"; }
+        ;;
+    *)
+        common::err "Invalid argument: ${uri}" ;;
+    esac
+```
+
+- [ ] **Step 5.2: Reject `zfs://` in `runtime::import`**
+
+In `src/runtime.sh:460-467`, change:
+
+```bash
+    case "${uri}" in
+    docker://*)
+        docker::import "${uri}" "${filename}" "${arch}" ;;
+    dockerd://* | podman://*)
+        docker::daemon::import "${uri}" "${filename}" "${arch}" ;;
+    *)
+        common::err "Invalid argument: ${uri}" ;;
+    esac
+```
+
+to:
+
+```bash
+    case "${uri}" in
+    docker://*)
+        docker::import "${uri}" "${filename}" "${arch}" ;;
+    dockerd://* | podman://*)
+        docker::daemon::import "${uri}" "${filename}" "${arch}" ;;
+    zfs://*)
+        common::err "zfs:// has no portable file artifact; use 'enroot load zfs://...'" ;;
+    *)
+        common::err "Invalid argument: ${uri}" ;;
+    esac
+```
+
+- [ ] **Step 5.3: Verify pull**
+
+Set up two ZFS hosts (or use ssh to localhost). On the source side, create `pulldonor`. Then on the target side:
+
+```sh
+/tmp/enroot/usr/bin/enroot load zfs://localhost/pulldonor -n pulled
+ls /srv/enroot/$USER/pulled/etc/os-release
+/tmp/enroot/usr/bin/enroot remove -f pulled
+```
+
+Expected: `os-release` readable.
+
+- [ ] **Step 5.4: Verify import rejection**
+
+```sh
+/tmp/enroot/usr/bin/enroot import zfs://localhost/anything 2>&1 | grep -q "no portable file artifact" && echo OK
+```
+
+Expected: `OK`.
+
+- [ ] **Step 5.5: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Add zfs:// URI to enroot load; reject it on import"
+```
+
+---
+
+### Task 6: Wire `zfs://` into `runtime::export` (push)
+
+**Files:**
+- Modify: `src/runtime.sh` `runtime::export`
+
+- [ ] **Step 6.1: Detect `zfs://` destination at the top of the function**
+
+In `runtime::export` (extended in Plan C), add a `zfs://` destination branch *before* the format dispatch:
+
+```bash
+runtime::export() {
+    local rootfs="$1" filename="$2" format="${3:-sqsh}"
+    ...
+    if [[ "${filename}" == zfs://* ]]; then
+        if ! zfs::enabled; then
+            common::err "zfs:// requires ENROOT_STORAGE_BACKEND=zfs"
+        fi
+        local host remote_name
+        zfs::parse_uri "${filename}" \
+          | { common::read -r host; common::read -r remote_name; }
+        [ -z "${remote_name##*/}" ] && remote_name="${remote_name}/${rootfs}"
+        # If user wrote zfs://host (no path), default the remote name to ours.
+        case "${remote_name}" in
+            "") remote_name="${rootfs}" ;;
+        esac
+        common::log INFO "Pushing ${rootfs} to ${host} as ${remote_name}"
+        zfs::send_clone_stdout "${rootfs}" \
+          | ssh "${host}" enroot import --zfs-recv -n "${remote_name}"
+        return
+    fi
+    ...
+}
+```
+
+(Place the new block immediately after the variable declarations, before the existing `--format` checks.)
+
+- [ ] **Step 6.2: Verify push**
+
+```sh
+/tmp/enroot/usr/bin/enroot create -n pushdonor alpine.sqsh
+/tmp/enroot/usr/bin/enroot export pushdonor zfs://localhost/pushed
+ssh localhost 'zfs list | grep pushed'
+ssh localhost '/tmp/enroot/usr/bin/enroot remove -f pushed'
+/tmp/enroot/usr/bin/enroot remove -f pushdonor
+```
+
+Expected: `pushed` listed on the remote side; remote remove succeeds.
+
+- [ ] **Step 6.3: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Add zfs:// destination to enroot export"
+```
+
+---
+
+### Task 7: Update user-facing usage strings
+
+**Files:**
+- Modify: `enroot.in:174-188` (import usage), `:202-215` (load usage), `:163-172` (export usage)
+
+- [ ] **Step 7.1: Add `zfs://` to the load schemes list**
+
+In the load usage block (lines 202-215), add a row to the `Schemes:` table:
+
+```
+   zfs://[USER@]HOST/NAME                  Pull a container from a remote enroot host (full zfs send stream over SSH)
+```
+
+- [ ] **Step 7.2: Update the export usage to mention `zfs://` output**
+
+```
+ Options:
+   -o, --output  Output destination: a filename or a zfs:// URI (defaults to "NAME.sqsh")
+   -f, --force   Overwrite an existing image
+       --format  Output format for file destinations: "sqsh" (default) or "zfs"
+```
+
+- [ ] **Step 7.3: Note explicitly that `enroot import zfs://` is invalid**
+
+In the import usage (lines 174-188), under `Schemes:`, do *not* add `zfs://` — but optionally add a one-line note above the schemes:
+
+```
+ Note: zfs:// images have no portable file form; use "enroot load zfs://..." instead.
+```
+
+- [ ] **Step 7.4: Commit**
+
+```sh
+git add enroot.in
+git commit -s -m "Document zfs:// URI in load and export usage strings"
+```
+
+---
+
+### Task 8: Document Plan D as implemented
+
+**Files:**
+- Modify: `doc/zfs.md`
+
+- [ ] **Step 8.1: Update status note**
+
+Update `doc/zfs.md` to mark Plan D (`zfs://` URI transport) as landed.
+
+- [ ] **Step 8.2: End-to-end smoke**
+
+```sh
+# Pull then push round-trip:
+/tmp/enroot/usr/bin/enroot create -n a alpine.sqsh
+/tmp/enroot/usr/bin/enroot export a zfs://localhost/b
+/tmp/enroot/usr/bin/enroot remove -f a
+/tmp/enroot/usr/bin/enroot load zfs://localhost/b -n c
+diff -q <(ls /srv/enroot/$USER/c/etc) <(ls /srv/enroot/$USER/c/etc) && echo OK
+ssh localhost '/tmp/enroot/usr/bin/enroot remove -f b'
+/tmp/enroot/usr/bin/enroot remove -f c
+```
+
+Expected: round-trip succeeds.
+
+- [ ] **Step 8.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan D (zfs:// URI) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: `zfs://host/NAME` parsing (T4), pull via load (T5), push via export (T6), reject import (T5.2), no incremental (only full sends — `zfs::send_clone_stdout` and `zfs::recv_to_template_stdin` use plain `zfs send` / `zfs receive`), pool/dataset paths don't leak (URI uses container *name*, not dataset path; remote enroot resolves locally).
+- [x] Type consistency: `zfs::recv_to_template_stdin`, `zfs::send_clone_stdout`, `zfs::parse_uri` defined in T1/T4, used in T5/T6.
+- [x] No placeholders.
+
+## Execution Handoff
+
+Same options as Plan A.

--- a/doc/plans/2026-04-29-zfs-e-ephemeral-start.md
+++ b/doc/plans/2026-04-29-zfs-e-ephemeral-start.md
@@ -1,0 +1,276 @@
+# ZFS Backend Plan E: ZFS Path for Ephemeral `start <image>`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the user runs `enroot start foo.sqsh` (no prior `create` — the image path is given directly), and `ENROOT_STORAGE_BACKEND=zfs`, substitute the existing `squashfuse + overlayfs` ephemeral mount with `ensure_template + zfs clone` to a unique throwaway dataset that is destroyed when the container exits. Existing behavior on the `dir` backend, and on non-ZFS hosts, is unchanged.
+
+**Architecture:** Branch in `runtime::_mount_rootfs` (`src/runtime.sh:174-211`). On the ZFS path, the function instead arranges for an ephemeral clone, returns its mountpoint as the new `_rootfs`, and registers a cleanup hook so the clone is destroyed even if the parent process is killed. The fuse-shim machinery is bypassed entirely on this path.
+
+**Depends on:** Plan A.
+
+**Prerequisite host setup:** Same as Plan A.
+
+---
+
+## Files
+
+- **Modify:** `src/runtime.sh:174-211` (`runtime::_mount_rootfs`).
+- **Modify:** `src/runtime.sh:213-282` (`runtime::_start`) — register cleanup.
+- **Modify:** `src/storage_zfs.sh` — add `zfs::ephemeral_clone`, `zfs::ephemeral_destroy`.
+
+---
+
+### Task 1: Add `zfs::ephemeral_clone` and `zfs::ephemeral_destroy`
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 1.1: Add the helpers**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+readonly zfs_ephemeral_subdir=".ephemeral"
+
+# Creates an ephemeral clone of the template for the given image and prints its
+# mountpoint. The clone name embeds the host PID for uniqueness and so the
+# cleanup hook can find it. The container is intended to be torn down when the
+# enroot process exits.
+zfs::ephemeral_clone() {
+    local -r image="$1"
+    local -r store=$(zfs::store_dataset)
+    local sha template clone mountpoint
+
+    sha=$(zfs::image_sha256 "${image}")
+    template=$(zfs::ensure_template "${image}" "${sha}")
+
+    clone="${store}/${zfs_ephemeral_subdir}/${$}-${sha:0:12}"
+    zfs create -p "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
+    zfs clone "${template}@${zfs_pristine_snap}" "${clone}"
+    zfs set readonly=off "${clone}"
+
+    mountpoint=$(zfs get -H -o value mountpoint "${clone}")
+    printf "%s\t%s" "${clone}" "${mountpoint}"
+}
+
+# Destroys an ephemeral clone. Best-effort; intended for cleanup hooks.
+zfs::ephemeral_destroy() {
+    local -r clone="$1"
+    [ -z "${clone}" ] && return
+    zfs destroy "${clone}" 2> /dev/null || :
+}
+```
+
+- [ ] **Step 1.2: Verify standalone**
+
+```sh
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         out=$(zfs::ephemeral_clone alpine.sqsh)
+         echo "got: ${out}"
+         clone="${out%%	*}"
+         mp="${out##*	}"
+         ls "${mp}/etc/os-release" && echo OK
+         zfs::ephemeral_destroy "${clone}"
+         zfs list | grep -q ephemeral || echo "cleaned"'
+```
+
+Expected: `OK` and `cleaned`.
+
+- [ ] **Step 1.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::ephemeral_clone and zfs::ephemeral_destroy"
+```
+
+---
+
+### Task 2: Branch `runtime::_mount_rootfs` on backend
+
+**Files:**
+- Modify: `src/runtime.sh:174-211` (`runtime::_mount_rootfs`)
+
+- [ ] **Step 2.1: Add a ZFS branch at the top of the function**
+
+In `src/runtime.sh:174`, change:
+
+```bash
+runtime::_mount_rootfs() {
+    local -r image="$1" rootfs="$2"
+    local pid=0 rv=0
+
+    common::checkcmd squashfuse mountpoint
+    if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
+        common::checkcmd fuse-overlayfs
+    fi
+    ...
+```
+
+to:
+
+```bash
+runtime::_mount_rootfs() {
+    local -r image="$1" rootfs="$2"
+    local pid=0 rv=0
+
+    if zfs::enabled; then
+        runtime::_mount_rootfs_zfs "${image}" "${rootfs}"
+        return
+    fi
+
+    common::checkcmd squashfuse mountpoint
+    if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
+        common::checkcmd fuse-overlayfs
+    fi
+    ...
+```
+
+(Leave the existing body intact below the new branch — that path is still used on non-ZFS hosts and on the `dir` backend.)
+
+- [ ] **Step 2.2: Add `runtime::_mount_rootfs_zfs`**
+
+Append a new function to `src/runtime.sh` (after `runtime::_mount_rootfs`):
+
+```bash
+runtime::_mount_rootfs_zfs() {
+    local -r image="$1" rootfs="$2"
+    local out clone mountpoint
+
+    zfs::checkenv
+
+    out=$(zfs::ephemeral_clone "${image}")
+    clone="${out%%$'\t'*}"
+    mountpoint="${out##*$'\t'}"
+
+    # Make the ephemeral clone visible at the canonical rootfs path the caller expects.
+    # The caller will bind-mount and pivot from this path; we redirect by bind-mounting
+    # the clone's mountpoint onto the placeholder rootfs.
+    cat <<- EOF | enroot-mount -
+	${mountpoint} ${rootfs} none rbind
+	EOF
+
+    # Register cleanup. Stash the clone name in a runtime file so the parent shell
+    # can destroy it after the container exits (see runtime::_start).
+    printf "%s\n" "${clone}" > "${ENROOT_RUNTIME_PATH}/zfs_ephemeral"
+}
+```
+
+- [ ] **Step 2.3: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Branch runtime::_mount_rootfs on ZFS backend for ephemeral starts"
+```
+
+---
+
+### Task 3: Wire ephemeral cleanup in `runtime::_start`
+
+**Files:**
+- Modify: `src/runtime.sh:213-282` (`runtime::_start`)
+
+- [ ] **Step 3.1: Add a trap that destroys the ephemeral clone**
+
+In `runtime::_start`, locate the existing `trap` setup or the area near the top of the function. Add:
+
+```bash
+    # If we created an ephemeral ZFS clone in _mount_rootfs, destroy it on exit.
+    if [ -f "${ENROOT_RUNTIME_PATH}/zfs_ephemeral" ]; then
+        local zfs_ephemeral_clone
+        zfs_ephemeral_clone=$(< "${ENROOT_RUNTIME_PATH}/zfs_ephemeral")
+        trap 'zfs::ephemeral_destroy "${zfs_ephemeral_clone}"' EXIT
+    fi
+```
+
+Place this after the existing tmpfs setup (around line 226), but before the rootfs mount block at line 232.
+
+- [ ] **Step 3.2: Verify ephemeral lifecycle end-to-end**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+zfs list -t all | grep ephemeral || echo "none yet"
+/tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/echo hello
+zfs list -t all | grep ephemeral || echo "cleaned"
+```
+
+Expected: first check prints `none yet`; the start prints `hello`; final check prints `cleaned`.
+
+- [ ] **Step 3.3: Verify the template stays warm across ephemeral starts**
+
+```sh
+# First start: extract.
+time /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
+# Second start: should be fast (template already cached).
+time /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
+zfs list -t all -r tank/enroot/$USER/.templates | head
+```
+
+Expected: second invocation noticeably faster; template persists.
+
+- [ ] **Step 3.4: Verify `dir` backend ephemeral start still uses overlayfs**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+export ENROOT_DATA_PATH=$HOME/.local/share/enroot
+/tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/echo hello
+```
+
+Expected: prints `hello`. Squashfuse + overlayfs path was used (no ZFS calls).
+
+- [ ] **Step 3.5: Commit**
+
+```sh
+git add src/runtime.sh
+git commit -s -m "Add ephemeral ZFS clone cleanup on container exit"
+```
+
+---
+
+### Task 4: Document Plan E as implemented
+
+**Files:**
+- Modify: `doc/zfs.md`
+
+- [ ] **Step 4.1: Update status note**
+
+Update `doc/zfs.md` to mark Plan E (ephemeral start ZFS path) as landed.
+
+- [ ] **Step 4.2: End-to-end smoke**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+zfs list -t all -r tank/enroot/$USER | wc -l
+for i in 1 2 3 4 5; do
+    /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
+done
+zfs list -t all -r tank/enroot/$USER | wc -l   # should be the same as before — only the warm template, no ephemeral leftovers
+zfs list -t all -r tank/enroot/$USER | grep ephemeral && echo BAD || echo OK
+```
+
+Expected: `OK`.
+
+- [ ] **Step 4.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan E (ephemeral start ZFS path) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: ZFS path for ephemeral `start <image>` (T2, T3); cleanup on exit (T3.1); template-cache reuse across ephemeral starts (T3.3); non-ZFS path untouched (T2.1 leaves the original block intact below the branch; T3.4 verifies).
+- [x] Type consistency: `zfs::ephemeral_clone`, `zfs::ephemeral_destroy` from T1 are referenced in T2, T3.
+- [x] No placeholders.
+
+## Known limitations
+
+- The ephemeral clone goes to a `.ephemeral/` subdataset rather than tmpfs; if the container writes huge amounts of throwaway data, it counts against the pool's quota until destroy. A future plan could bound this with a per-clone quota.
+- Cleanup is best-effort via shell trap. If `enroot` is hard-killed (`kill -9`), the ephemeral clone leaks until the next manual cleanup or process restart. A safety net (sweep `.ephemeral/` for clones whose PID is dead) could be added to `zfs::sweep_templates` if leaks become a problem in practice.
+
+## Execution Handoff
+
+Same options as Plan A.

--- a/doc/plans/2026-04-29-zfs-f-docker-load.md
+++ b/doc/plans/2026-04-29-zfs-f-docker-load.md
@@ -1,0 +1,408 @@
+# ZFS Backend Plan F: ZFS Path for `enroot load docker://`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `ENROOT_STORAGE_BACKEND=zfs`, `enroot load docker://...` stops requiring `ENROOT_NATIVE_OVERLAYFS=y`. Layers are stacked as a chain of ZFS clones (mirroring Docker's own `zfs` storage driver): each layer is `zfs clone parent@done`, the layer tarball is extracted into the clone with whiteout handling, then `zfs snapshot @done`. The leaf snapshot becomes the cached template's `@pristine`, and a clone of that becomes the user's container.
+
+**Architecture:** Add `zfs::stack_layers` that takes the same layer-tarball list `docker::_prepare_layers` produces and replays it onto a fresh chain of ZFS datasets. Modify `docker::load` to dispatch on backend: existing `enroot-mksquashovlfs` path stays for the `dir` backend; ZFS path uses `zfs::stack_layers` and skips the `ENROOT_NATIVE_OVERLAYFS=y` precondition.
+
+**Depends on:** Plan A.
+
+**Prerequisite host setup:** Same as Plan A. Test image: `alpine` from Docker Hub (small, exercises whiteouts via standard Docker tooling).
+
+---
+
+## Files
+
+- **Modify:** `src/storage_zfs.sh` — add `zfs::stack_layers`, `zfs::extract_layer_tarball`.
+- **Modify:** `src/docker.sh:488-548` (`docker::load`) — backend dispatch.
+
+---
+
+### Task 1: Add `zfs::extract_layer_tarball` (whiteout-aware)
+
+Docker layer tarballs use AUFS-style whiteouts: `.wh.foo` means "delete `foo` from lower layers"; `.wh..wh..opq` in a directory means "ignore everything from lower layers in this directory." When stacking with overlayfs, the kernel handles these. With ZFS clones, we replicate the semantics manually.
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 1.1: Add the helper**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Extracts a single Docker layer tarball into the given mountpoint with
+# whiteout/opaque-marker handling, suitable for use on top of a parent layer's
+# ZFS clone. Handles both compressed and uncompressed tarballs.
+zfs::extract_layer_tarball() {
+    local -r tarball="$1" mountpoint="$2"
+
+    common::checkcmd tar awk find
+
+    # Pass 1: extract everything except whiteout markers.
+    tar --numeric-owner -C "${mountpoint}" -xpf "${tarball}" \
+        --exclude='.wh.*' --exclude='.wh..wh..opq' 2> /dev/null || \
+    tar --numeric-owner -C "${mountpoint}" -xpf "${tarball}" \
+        --exclude='.wh.*' --exclude='.wh..wh..opq'   # surface real errors on retry
+
+    # Pass 2: list whiteout markers and apply them to the tree.
+    tar -tf "${tarball}" 2> /dev/null | awk '
+        /\/\.wh\..*$/  { sub(/\.wh\.([^/]+)$/, "\\1"); print "del\t"$0; next }
+        /^\.wh\..*$/   { sub(/^\.wh\./, "");           print "del\t"$0; next }
+        /\.wh\..wh..opq$/ { sub(/\.wh\..wh..opq$/, ""); print "opq\t"$0; next }
+    ' | while IFS=$'\t' read -r kind path; do
+        case "${kind}" in
+            del)
+                rm -rf "${mountpoint}/${path}" 2> /dev/null || :
+                ;;
+            opq)
+                # Opaque dir: clear everything in this directory from lower layers.
+                # The directory itself was already created by this layer's pass 1
+                # (or already exists from a parent). Remove all children, then let
+                # pass 1's content (which we've already laid down) repopulate.
+                find "${mountpoint}/${path}" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2> /dev/null || :
+                # Re-extract the directory's contents from this tar without the wh markers.
+                tar --numeric-owner -C "${mountpoint}" -xpf "${tarball}" \
+                    --exclude='.wh.*' --exclude='.wh..wh..opq' \
+                    "${path}" 2> /dev/null || :
+                ;;
+        esac
+    done
+}
+```
+
+- [ ] **Step 1.2: Verify with a hand-built tarball**
+
+```sh
+mkdir /tmp/wh-test && cd /tmp/wh-test
+mkdir -p layer1/usr/bin layer2
+echo "old" > layer1/usr/bin/foo
+echo "x"   > layer1/keep_me
+( cd layer2 && touch usr/bin/.wh.foo )    # delete /usr/bin/foo
+tar --numeric-owner -C layer1 -cf l1.tar .
+tar --numeric-owner -C layer2 -cf l2.tar .
+
+mkdir target
+tar -C target -xpf l1.tar
+ls target/usr/bin/foo  # exists
+
+bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
+         source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
+         zfs::extract_layer_tarball /tmp/wh-test/l2.tar /tmp/wh-test/target'
+ls /tmp/wh-test/target/usr/bin/foo 2>&1 | grep -q "No such" && echo "deleted OK"
+ls /tmp/wh-test/target/keep_me && echo "preserved OK"
+cd && rm -rf /tmp/wh-test
+```
+
+Expected: `deleted OK` and `preserved OK`.
+
+- [ ] **Step 1.3: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::extract_layer_tarball with whiteout/opaque handling"
+```
+
+---
+
+### Task 2: Add `zfs::stack_layers`
+
+**Files:**
+- Modify: `src/storage_zfs.sh` (append)
+
+- [ ] **Step 2.1: Add the function**
+
+Append to `src/storage_zfs.sh`:
+
+```bash
+# Stacks an ordered list of Docker layer tarballs as a chain of ZFS datasets.
+# Returns the final template's name (an existing template will be reused if its
+# leaf snapshot already exists).
+#
+# Inputs:
+#   $1 - cache key (typically sha256 of the manifest digest list, computed by caller)
+#   $2 - tab-separated list of layer tarball paths (one per line, in stack order
+#        from base to top), passed via stdin
+#
+# Output (stdout): the template dataset name.
+zfs::stack_layers() {
+    local -r cache_key="$1"
+    local -r store=$(zfs::store_dataset)
+    local -r template="${store}/${zfs_template_subdir}/${cache_key}"
+    local -r tmp="${template}.tmp"
+    local -r snap="${template}@${zfs_pristine_snap}"
+    local i timeout=600
+    local layers parent layer mountpoint i_layer=0
+
+    zfs::sweep_templates 2> /dev/null || :
+
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        zfs::touch_template "${template}" 2> /dev/null || :
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Read layer paths from stdin.
+    readarray -t layers
+
+    if zfs create -p "${tmp}" 2> /dev/null; then
+        parent="${tmp}"
+        for layer in "${layers[@]}"; do
+            [ -z "${layer}" ] && continue
+            if [ "${i_layer}" -eq 0 ]; then
+                # First layer extracts directly into the .tmp dataset.
+                mountpoint=$(zfs get -H -o value mountpoint "${parent}")
+                common::log INFO "Stacking layer 1/${#layers[@]}..."
+                zfs::extract_layer_tarball "${layer}" "${mountpoint}"
+                zfs snapshot "${parent}@layer-${i_layer}"
+            else
+                # Subsequent layers clone the previous snapshot, then extract.
+                local child="${tmp}-l${i_layer}"
+                zfs clone "${parent}@layer-$((i_layer - 1))" "${child}"
+                mountpoint=$(zfs get -H -o value mountpoint "${child}")
+                common::log INFO "Stacking layer $((i_layer + 1))/${#layers[@]}..."
+                zfs::extract_layer_tarball "${layer}" "${mountpoint}"
+                zfs snapshot "${child}@layer-${i_layer}"
+                parent="${child}"
+            fi
+            i_layer=$((i_layer + 1))
+        done
+
+        # The 'parent' variable now points at the leaf clone. Promote it so it
+        # becomes the new template root, then clean up the intermediate chain.
+        if [ "${parent}" != "${tmp}" ]; then
+            zfs promote "${parent}"
+        fi
+        zfs rename "${parent}" "${template}"
+        zfs snapshot "${snap}"
+
+        # Best-effort cleanup of intermediate datasets/snapshots.
+        local left
+        for left in $(zfs list -H -o name -r "${store}/${zfs_template_subdir}" | grep -E "^${tmp//./\\.}(-l[0-9]+)?\$"); do
+            zfs destroy -r "${left}" 2> /dev/null || :
+        done
+
+        zfs set readonly=on "${template}"
+        zfs::touch_template "${template}" 2> /dev/null || :
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Lost the race or stale .tmp — wait for @pristine.
+    for ((i = 0; i < timeout; i++)); do
+        if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            printf "%s" "${template}"
+            return
+        fi
+        sleep 1
+    done
+    common::err "Timed out waiting for layer-stack template: ${template}"
+}
+```
+
+- [ ] **Step 2.2: Commit**
+
+```sh
+git add src/storage_zfs.sh
+git commit -s -m "Add zfs::stack_layers for Docker layer-stack templates"
+```
+
+---
+
+### Task 3: Branch `docker::load` on backend
+
+**Files:**
+- Modify: `src/docker.sh:488-548`
+
+- [ ] **Step 3.1: Replace the `ENROOT_NATIVE_OVERLAYFS=y` precondition with a backend-conditional check**
+
+In `src/docker.sh:488-495`, change:
+
+```bash
+docker::load() (
+    local -r uri="$1"
+    local name="$2" arch="$3"
+    local user= registry= image= tag= tmpdir= config= layer_count=
+
+    if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
+        common::err "ENROOT_NATIVE_OVERLAYFS=y is required for enroot load"
+    fi
+    ...
+```
+
+to:
+
+```bash
+docker::load() (
+    local -r uri="$1"
+    local name="$2" arch="$3"
+    local user= registry= image= tag= tmpdir= config= layer_count=
+
+    if ! zfs::enabled && [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
+        common::err "ENROOT_NATIVE_OVERLAYFS=y or ENROOT_STORAGE_BACKEND=zfs is required for enroot load"
+    fi
+    ...
+```
+
+- [ ] **Step 3.2: Add backend dispatch for the layer-stacking step**
+
+In `src/docker.sh`, after `docker::_prepare_layers` returns and before the existing `enroot-nsenter ... overlay` block (around line 545), add a backend dispatch.
+
+Locate the existing block (lines 535-547):
+
+```bash
+    # Create the final filesystem by overlaying all the layers and copying to target rootfs.
+    common::log INFO "Loading container root filesystem..." NL
+
+    # Check if we're running unprivileged.
+    if [ "${EUID}" -ne 0 ]; then
+        unpriv=y
+    fi
+
+    # Create a mount namespace and overlay mount
+    mkdir -p rootfs "${name}"
+    enroot-nsenter ${unpriv:+--user} --mount --remap-root \
+            bash -c "mount --make-rprivate / && mount -t overlay overlay -o lowerdir=0:$(seq -s: 1 "${layer_count}") rootfs &&
+                     tar --numeric-owner -C rootfs/ --mode=u-s,g-s -cpf - . | tar --numeric-owner -C '${name}/' -xpf -"
+)
+```
+
+Wrap it in a backend conditional:
+
+```bash
+    common::log INFO "Loading container root filesystem..." NL
+
+    if zfs::enabled; then
+        # ZFS path: stack layers as a chain of clones; final template, then clone for the user.
+        local cache_key template
+        # The cache key is the sha256 of the layer-tarball list (stable per-image).
+        cache_key=$(printf "%s\n" 0 $(seq 1 "${layer_count}") | xargs -I{} sha256sum {} 2>/dev/null \
+                    | awk '{print $1}' | sha256sum | awk '{print $1}')
+
+        # Build the absolute paths to the layer tarballs already prepared in $tmpdir.
+        # docker::_prepare_layers leaves layers at "0", "1", ..., "${layer_count}" relative
+        # to the cwd at this point. Pass them in stack order (0 first if present, then 1..N).
+        local -a layer_paths=()
+        [ -e 0 ] && layer_paths+=("$(common::realpath 0)")
+        for i in $(seq 1 "${layer_count}"); do
+            [ -e "${i}" ] && layer_paths+=("$(common::realpath "${i}")")
+        done
+
+        template=$(printf "%s\n" "${layer_paths[@]}" | zfs::stack_layers "${cache_key}")
+        zfs::clone_container "${template}" "${name##*/}"
+    else
+        # Check if we're running unprivileged.
+        if [ "${EUID}" -ne 0 ]; then
+            unpriv=y
+        fi
+
+        # Create a mount namespace and overlay mount
+        mkdir -p rootfs "${name}"
+        enroot-nsenter ${unpriv:+--user} --mount --remap-root \
+                bash -c "mount --make-rprivate / && mount -t overlay overlay -o lowerdir=0:$(seq -s: 1 "${layer_count}") rootfs &&
+                         tar --numeric-owner -C rootfs/ --mode=u-s,g-s -cpf - . | tar --numeric-owner -C '${name}/' -xpf -"
+    fi
+)
+```
+
+NOTE: `docker::_prepare_layers` writes layer tarballs into the cwd (`$tmpdir`) under integer names; the existing overlay path already references them as `0:$(seq -s: 1 "${layer_count}")`. The exact naming convention (`0`, `1`, …, `N`, with `0` being the empty/lower marker) should be confirmed by reading `docker::_prepare_layers` (`src/docker.sh:306`) before implementing this task. If the naming differs, adjust the layer-paths construction.
+
+- [ ] **Step 3.3: Verify ZFS-backed `enroot load`**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+export ENROOT_DATA_PATH=/srv/enroot/$USER
+unset ENROOT_NATIVE_OVERLAYFS
+/tmp/enroot/usr/bin/enroot load docker://alpine -n alpine_loaded
+ls /srv/enroot/$USER/alpine_loaded/etc/os-release
+zfs list | grep alpine_loaded
+/tmp/enroot/usr/bin/enroot remove -f alpine_loaded
+```
+
+Expected: load succeeds without `ENROOT_NATIVE_OVERLAYFS=y`; clone is listed; os-release readable.
+
+- [ ] **Step 3.4: Verify `dir` backend `enroot load` still requires `ENROOT_NATIVE_OVERLAYFS=y` (no regression)**
+
+```sh
+unset ENROOT_STORAGE_BACKEND
+unset ENROOT_NATIVE_OVERLAYFS
+/tmp/enroot/usr/bin/enroot load docker://alpine -n a 2>&1 | grep -q "is required" && echo OK
+ENROOT_NATIVE_OVERLAYFS=y /tmp/enroot/usr/bin/enroot load docker://alpine -n a
+/tmp/enroot/usr/bin/enroot remove -f a
+```
+
+Expected: first invocation errors with the precondition message (`OK`); second succeeds.
+
+- [ ] **Step 3.5: Verify whiteouts work end-to-end**
+
+Use a test image with known whiteouts (any multi-layer image where a later layer deletes a file from an earlier one — `python:3-slim` is a common example):
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+/tmp/enroot/usr/bin/enroot load docker://python:3-slim -n py
+ls /srv/enroot/$USER/py/usr/bin/python3 && echo "ok"
+# Check no .wh. files leaked through:
+find /srv/enroot/$USER/py -name '.wh.*' | head && echo "BAD" || echo "clean"
+/tmp/enroot/usr/bin/enroot remove -f py
+```
+
+Expected: `ok` and `clean`.
+
+- [ ] **Step 3.6: Commit**
+
+```sh
+git add src/docker.sh
+git commit -s -m "Branch docker::load on ENROOT_STORAGE_BACKEND; lift overlay precondition for ZFS"
+```
+
+---
+
+### Task 4: Document Plan F as implemented
+
+**Files:**
+- Modify: `doc/zfs.md`
+
+- [ ] **Step 4.1: Update status note**
+
+Update `doc/zfs.md` to mark Plan F (Docker layer stacking on ZFS) as landed.
+
+- [ ] **Step 4.2: End-to-end smoke**
+
+```sh
+export ENROOT_STORAGE_BACKEND=zfs
+unset ENROOT_NATIVE_OVERLAYFS
+/tmp/enroot/usr/bin/enroot load docker://alpine -n a
+/tmp/enroot/usr/bin/enroot start a /bin/cat /etc/os-release
+/tmp/enroot/usr/bin/enroot load docker://alpine -n b   # second time should reuse template
+zfs list -t all | grep templates | wc -l               # should be 1, not 2
+/tmp/enroot/usr/bin/enroot remove -f a b
+```
+
+Expected: both loads succeed; only one template remains.
+
+- [ ] **Step 4.3: Commit**
+
+```sh
+git add doc/zfs.md
+git commit -s -m "Mark Plan F (Docker load ZFS path) as implemented"
+```
+
+---
+
+## Self-review checklist
+
+- [x] Spec coverage: ZFS layer-stacking instead of mksquashovlfs (T2, T3.2); `ENROOT_NATIVE_OVERLAYFS=y` precondition lifted on ZFS (T3.1, T3.3); whiteout & opaque-dir handling (T1, T3.5); cache reuse across loads of same image (T2 fast-path, T4.2 verifies); `dir` backend behavior unchanged (T3.4 regression check).
+- [x] Type consistency: `zfs::extract_layer_tarball`, `zfs::stack_layers` defined in T1, T2; both used in T3.
+- [x] No placeholders.
+
+## Known limitations & open questions
+
+- **Step 3.2 has an explicit caveat** about `docker::_prepare_layers`'s on-disk naming. The implementer must read `src/docker.sh:306-330` and confirm before writing the layer-paths array. If `_prepare_layers` writes to a different layout, the array construction must be adjusted accordingly.
+- **`zfs promote` on the leaf** is the canonical way to "flatten" a clone chain into a standalone dataset. We do this so the intermediate `-l1`, `-l2`, … datasets can be destroyed and the cache stores only the final template. If `zfs promote` is unavailable for the user's delegations, an alternative is to keep the chain alive and accept extra dataset objects (no functional impact, just `zfs list` clutter).
+- **Per-layer xattr handling** (capability bits, immutable flags, security.* attrs) is the same as Docker's own `zfs` driver — `tar --numeric-owner` plus the `xattr=sa` filesystem property carries them. Note in `doc/zfs.md` admin recipe (already covered there as a default).
+- **Concurrent `enroot load` of the same image** is race-safe via the same `.tmp` lock as Plan A's `ensure_template` — losers wait for `@pristine`.
+- **Sparse files in layers** are not specially handled; tar's default sparse handling applies. Likely fine for v1.
+
+## Execution Handoff
+
+Same options as Plan A.

--- a/doc/plans/README.md
+++ b/doc/plans/README.md
@@ -1,0 +1,29 @@
+# Implementation plans
+
+Plans for landing the optional ZFS storage backend designed in [`../zfs.md`](../zfs.md). Each plan produces working, testable software on its own and is sized to be picked up independently.
+
+| Plan | File | Depends on |
+| ---- | ---- | ---------- |
+| A. Foundation — `ENROOT_STORAGE_BACKEND=zfs`, clone-on-create, fast remove | [2026-04-29-zfs-a-foundation.md](2026-04-29-zfs-a-foundation.md) | — |
+| B. Template warm/cold lifecycle — `ENROOT_TEMPLATE_WARM_SECONDS`, pressure-based eviction, ENOSPC retry | [2026-04-29-zfs-b-template-lifecycle.md](2026-04-29-zfs-b-template-lifecycle.md) | A |
+| C. `.zfs` image format — `enroot create foo.zfs`, `enroot export --format=zfs` | [2026-04-29-zfs-c-zfs-format.md](2026-04-29-zfs-c-zfs-format.md) | A |
+| D. `zfs://` URI transport — `enroot load zfs://host/NAME`, `enroot export NAME zfs://host` | [2026-04-29-zfs-d-zfs-uri.md](2026-04-29-zfs-d-zfs-uri.md) | A, C |
+| E. Ephemeral start ZFS path — substitute `squashfuse + overlay` with throwaway clone | [2026-04-29-zfs-e-ephemeral-start.md](2026-04-29-zfs-e-ephemeral-start.md) | A |
+| F. Docker layer-stack ZFS path — lift `ENROOT_NATIVE_OVERLAYFS=y` requirement on ZFS hosts | [2026-04-29-zfs-f-docker-load.md](2026-04-29-zfs-f-docker-load.md) | A |
+
+```
+A ─┬─> B
+   ├─> C ─> D
+   ├─> E
+   └─> F
+```
+
+Recommended landing order: **A → E → F → B → C → D**. A is the foundation; E/F give the most user-visible wins next; B improves cache economics; C/D add transport options.
+
+## Conventions used by these plans
+
+- **No automated test suite.** Verification per task is a "run command X, expect Y" block. If the project gains a test framework (e.g., bats), retrofit the plans' verification blocks into proper tests.
+- **DCO sign-off (`-s`) on every commit.** Required by `CONTRIBUTING.md`.
+- **Frequent commits.** Each numbered task ends with a commit. Keeps blame and bisection useful.
+- **Templates and ephemeral clones live under `.templates/` and `.ephemeral/` subdatasets** of `${ENROOT_DATA_PATH}`. They are dotfiles so `enroot list` does not show them.
+- **All ZFS-specific helpers are in `src/storage_zfs.sh`** under the `zfs::` namespace. Other modules import behavior via `zfs::enabled` predicates and named helpers; they should not call `zfs(8)` directly.

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -1,6 +1,6 @@
 # ZFS storage backend
 
-This document describes an optional ZFS-aware mode for the enroot container store. It is a design proposal — not yet implemented. The default storage backend (plain directories under `ENROOT_DATA_PATH`) is unchanged and remains the only option on hosts without ZFS.
+This document describes an optional ZFS-aware mode for the enroot container store. **Plan A (foundation) is implemented**: `enroot create` and `enroot remove` use ZFS datasets when `ENROOT_STORAGE_BACKEND=zfs`. The remaining substitutions (template warm/cold lifecycle, `.zfs` file format, `zfs://` URI, ephemeral-start ZFS path, Docker layer stacking on ZFS) are tracked under `doc/plans/`. The default storage backend (plain directories under `ENROOT_DATA_PATH`) is unchanged and remains the only option on hosts without ZFS.
 
 ## Motivation
 
@@ -198,6 +198,13 @@ A site enabling the ZFS backend should:
    ```
 
    `zfs receive` from `.zfs` files and `zfs://` requires this delegation. Without it, the ZFS backend operates only on already-received templates.
+
+   **Linux mount(2) caveat:** ZFS delegation governs ZFS's *internal* logic, but on Linux the kernel `mount(2)` syscall still requires `CAP_SYS_ADMIN`. As a result, an unprivileged user invoking `enroot create` on the ZFS backend will see "filesystem successfully created, but it may only be mounted by root" warnings, and the dataset will not be auto-mounted. The two practical workarounds:
+
+   - **Privileged `create`, unprivileged everything else.** Run `enroot create` (and `enroot load`) as root or via sudo; `enroot start`, `exec`, and `remove` work unprivileged because they operate on already-mounted datasets or use mount-namespace tricks that don't need additional CAP_SYS_ADMIN.
+   - **`fs.namespace.unprivileged_userns_clone=1` + per-user mount namespace.** A wrapper that enters a user namespace before `enroot create` lets the ZFS auto-mount succeed without root, at the cost of complexity and a small overhead.
+
+   On hosts where the same operator runs `create` and `start`, the privileged-create approach is simpler and matches enroot's existing model where image conversion (`enroot import`/`enroot-aufs2ovlfs`) already requires elevated privileges.
 
 4. **Configure `ENROOT_STORAGE_BACKEND=zfs`** in `enroot.conf` (or per-user). Set `ENROOT_DATA_PATH` to the mountpoint of `tank/enroot` (or per-user subdataset).
 

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -1,0 +1,232 @@
+# ZFS storage backend
+
+This document describes an optional ZFS-aware mode for the enroot container store. It is a design proposal — not yet implemented. The default storage backend (plain directories under `ENROOT_DATA_PATH`) is unchanged and remains the only option on hosts without ZFS.
+
+## Motivation
+
+Today, `enroot create foo.sqsh -n NAME` does a fresh `unsquashfs` of the entire image into `${ENROOT_DATA_PATH}/NAME`. Two creates from the same image produce two independent, fully-extracted copies on disk; nothing is shared. On HPC nodes where many users run containers built from a small set of common base images (CUDA, PyTorch, Ubuntu LTS), this wastes both extraction time and disk space.
+
+The ZFS backend is an *alternative storage driver*, in the same spirit as Docker's pluggable storage drivers (`overlay2`, `zfs`, `btrfs`, …). When configured, it substitutes ZFS-native operations for three of enroot's storage code paths — `create`, ephemeral `start <image>`, and `load docker://` — replacing extraction-per-create with extract-once-then-clone, and replacing overlay-on-squashfuse with throwaway clones. Hosts without ZFS, and the default `dir` backend on ZFS hosts, are untouched.
+
+## Configuration knobs
+
+| Setting | Default | Description |
+| ------ | ------ | ------ |
+| `ENROOT_STORAGE_BACKEND` | `dir` | `dir` = today's behavior. `zfs` = use ZFS datasets for the container store. |
+| `ENROOT_TEMPLATE_WARM_SECONDS` | `604800` (7 days) | How long a template with no clones remains evictable only under pressure. `0` = evict immediately when refcount reaches zero (refcount-only). `inf` = never auto-evict. |
+| `ENROOT_TEMPLATE_PRESSURE_THRESHOLD` | `0.80` | Templates dataset quota fraction above which routine `create`s start evicting warm templates. Soft signal; the ZFS quota is the hard wall. |
+
+When `ENROOT_STORAGE_BACKEND=zfs`, `ENROOT_DATA_PATH` must be the mountpoint of a ZFS dataset that the unprivileged user has been granted permission on (see [Admin setup](#admin-setup)).
+
+## Store layout
+
+```
+${pool}/${dataset}/templates/<sha256>            # one per distinct image content
+${pool}/${dataset}/templates/<sha256>@pristine   # snapshot taken after extraction
+${pool}/${dataset}/<user>/<container_name>       # clones of @pristine, the user's containers
+```
+
+Mountpoints follow the dataset hierarchy under `ENROOT_DATA_PATH`. Templates are not user-visible — `enroot list` only enumerates `<user>/<container_name>` clones. Templates have `readonly=on`; clones inherit the property override on `start -w`.
+
+The `templates` dataset is shared across all users on the host. Its quota and properties are admin-controlled (see below).
+
+## Container lifecycle
+
+### `enroot create` from `.sqsh`
+
+Input is a portable squashfs image, identical to today.
+
+1. Compute `sha256` of `foo.sqsh`.
+2. **Cache hit:** `templates/<sha256>@pristine` exists — skip to step 5.
+3. **Cache miss, win the extractor race:** atomically `zfs create templates/<sha256>.tmp`. The dataset's existence is the lock; whoever wins this is the extractor.
+4. **Extract:** `unsquashfs` into `templates/<sha256>.tmp`, then `zfs rename .tmp <sha256>`, `zfs snapshot @pristine`, `zfs set readonly=on`.
+5. **Cache miss, lost the race:** another process is extracting; wait for `@pristine` to appear (bounded poll). If the orphan `.tmp` is past timeout with no live process, destroy and retry from step 2.
+6. Update `enroot:last_used=<now>` on the template.
+7. `zfs clone templates/<sha256>@pristine <user>/<NAME>`.
+
+End state: the user's container is a fresh, writable dataset clone of an immutable shared template.
+
+### `enroot create` from `.zfs`
+
+A `.zfs` file is a `zfs send` stream — not a mountable filesystem, not portable across non-ZFS hosts. The flow mirrors `.sqsh` but replaces extraction with receive:
+
+| Step | `.sqsh` path | `.zfs` path |
+| ------ | ------ | ------ |
+| Cache key | `sha256` of file | `sha256` of file |
+| Materialize template | `unsquashfs` into dataset | `zfs recv` into dataset |
+| Snapshot | `zfs snapshot @pristine` | snapshot in stream is preserved |
+| Spawn container | `zfs clone @pristine` | `zfs clone @pristine` |
+
+`enroot create foo.zfs` on a non-ZFS host (`ENROOT_STORAGE_BACKEND≠zfs` or no ZFS pool) is a hard error: `.zfs` images require the ZFS backend. `.sqsh` images keep working everywhere.
+
+The dispatcher picks the path by file extension. There is no magic-byte sniffing; `.sqsh` is always squashfs and `.zfs` is always a stream.
+
+### `enroot remove`
+
+Destroys the user's clone:
+
+```
+zfs destroy ${pool}/${dataset}/<user>/<NAME>
+```
+
+This is fast, atomic, and naturally sidesteps the restricted-permission-directory failure mode of `rm -rf`.
+
+The template is **not** destroyed at remove time. It transitions to a warm state and waits for the eviction sweep on the next `create` (see below). This is a deliberate change from refcount-on-remove: `enroot remove` returns faster, but disk does not shrink immediately.
+
+### `enroot export NAME`
+
+Default output is `.sqsh`, produced by running `mksquashfs` against the live clone — identical to today's `enroot export` output, portable to any host.
+
+`enroot export NAME --format=zfs` produces `NAME.zfs` via `zfs send <user>/<NAME>@pristine > NAME.zfs`. Requires the source host to be running the ZFS backend.
+
+### `enroot bundle`
+
+Always produces a `.sqsh`-backed `.run`, regardless of source backend. Bundles must run on hosts without ZFS, so the bundle pipeline stays squashfs-only. If the source container is on ZFS, bundle runs `mksquashfs` against the clone first.
+
+## Image transport
+
+Three transports for the same logical content:
+
+| Transport | When to use | Portable? |
+| ------ | ------ | ------ |
+| `.sqsh` file | Default. Distribute to any audience. | Yes — any Linux host. |
+| `.zfs` file | ZFS-to-ZFS transfer via shared filesystem, sneakernet, S3. | No — receiver must run the ZFS backend. |
+| `zfs://host/NAME` URI | ZFS-to-ZFS transfer over SSH. | No — both hosts must run enroot with the ZFS backend. |
+
+### `zfs://` URI
+
+```
+enroot import zfs://host/ubuntu_2410          # disallowed; use load
+enroot load   zfs://host/ubuntu_2410 -n ub    # fetch + create in one step
+enroot export NAME zfs://host                 # push to remote
+enroot export NAME zfs://host/NAME2           # push and rename
+```
+
+Wire is `ssh host enroot ...`:
+
+- Pull: `ssh host enroot export --format=zfs NAME | zfs recv ...`
+- Push: `zfs send <user>/<NAME>@pristine | ssh host enroot import --zfs-recv -n NAME`
+
+The remote's pool name and store path never leak — the URI names a *container on a remote enroot host*, and the remote enroot resolves the local layout itself.
+
+`enroot import zfs://host/NAME` is disallowed because the scheme has no portable file artifact to produce. Use `enroot load zfs://host/NAME` (fetch + create in one step), or `zfs://` flows directly into the template cache.
+
+`zfs://` does not silently fall back to squashfs. If the remote does not understand `--format=zfs`, the operation fails loudly.
+
+Incremental sends (`zfs send -i`) are out of scope for v1. All `zfs://` and `.zfs` transports are full streams.
+
+## Template cache and eviction
+
+Templates are shared and refcount-tracked indirectly via ZFS clone relationships (`zfs list -H -t filesystem -o origin` enumerates clones of a snapshot). Each template has a single user property:
+
+```
+enroot:last_used=<unix_ts>     # updated on every clone (extract or reuse)
+```
+
+### Lifecycle states
+
+| State | Definition | Evictable? |
+| ------ | ------ | ------ |
+| Live | At least one clone exists. | No. |
+| Warm | No clones, `now - last_used < ENROOT_TEMPLATE_WARM_SECONDS`. | Only under disk pressure. |
+| Cold | No clones, `now - last_used >= ENROOT_TEMPLATE_WARM_SECONDS`. | Yes, routinely. |
+
+Live → Warm on `enroot remove` of the last clone. Warm → Live on `enroot create` reusing the template. Warm → Cold by passage of time.
+
+### Eviction triggers
+
+There is no `enroot gc` command and no daemon. All eviction happens implicitly on `enroot create`, in three modes:
+
+- **Routine sweep:** every `create` reaps all cold templates before extracting/receiving. Cheap because templates are few.
+- **Pressure sweep:** if the templates dataset has a quota set and `used/quota >= ENROOT_TEMPLATE_PRESSURE_THRESHOLD`, also reap warm templates LRU until back under the threshold.
+- **ENOSPC retry:** if `zfs recv` or `unsquashfs` fails for space (race, or quota too tight), reap any remaining warm templates and retry once. Hard fail on the second ENOSPC.
+
+### Algorithm
+
+```
+on enroot create:
+    candidates = templates with no clones, sorted by enroot:last_used ASC
+    pressure = (quota set on templates and used/quota >= PRESSURE_THRESHOLD)
+
+    for t in candidates:
+        is_warm = (now - t.last_used) < WARM_SECONDS
+        if is_warm and not pressure:
+            continue
+        zfs destroy t
+        if pressure and used/quota < PRESSURE_THRESHOLD:
+            break
+
+    extract/recv into templates/<sha>.tmp → rename → snapshot
+    zfs set enroot:last_used=<now> templates/<sha>
+    zfs clone templates/<sha>@pristine <user>/<NAME>
+```
+
+### Race handling
+
+A concurrent eviction can destroy a template's `@pristine` snapshot just as another `create` tries to clone from it. ZFS will fail one operation atomically. The handler is uniform across all such races — crashed extractors leaving orphan `.tmp` datasets, evicted-mid-clone, and never-snapshotted templates all collapse into the same recovery: fall through to the cache-miss path and re-extract.
+
+The pressure threshold is a soft signal, not a barrier. Two concurrent `create`s seeing "78% used" can both extract and overshoot — the ZFS quota refuses one with ENOSPC and the retry path catches it. The threshold prevents the common case; the quota is the hard wall.
+
+## Admin setup
+
+A site enabling the ZFS backend should:
+
+1. **Create a parent dataset** with enroot-friendly properties:
+
+   ```sh
+   zpool create tank ...                            # if not already present
+   zfs create -o compression=zstd \
+              -o atime=off \
+              -o xattr=sa \
+              -o acltype=posixacl \
+              -o mountpoint=/var/lib/enroot \
+              tank/enroot
+   zfs create tank/enroot/templates
+   ```
+
+2. **Set a quota on the templates dataset** to bound disk usage. Sizing rule of thumb: 2–3× the largest single image expected on the host.
+
+   ```sh
+   zfs set quota=200G tank/enroot/templates
+   ```
+
+3. **Delegate ZFS permissions** to unprivileged users so they can create, clone, and destroy datasets in their own namespace, and receive into the templates cache:
+
+   ```sh
+   zfs allow user create,mount,clone,destroy,snapshot,rename tank/enroot
+   zfs allow user receive tank/enroot/templates
+   ```
+
+   `zfs receive` from `.zfs` files and `zfs://` requires this delegation. Without it, the ZFS backend operates only on already-received templates.
+
+4. **Configure `ENROOT_STORAGE_BACKEND=zfs`** in `enroot.conf` (or per-user). Set `ENROOT_DATA_PATH` to the mountpoint of `tank/enroot` (or per-user subdataset).
+
+5. **For `zfs://` transport**, ensure passwordless SSH between hosts; standard `ssh_config` Host blocks (port, identity, jump hosts) are honored.
+
+6. **For Docker layer stacking on ZFS** (`enroot load docker://...`), no extra setup beyond the delegations above. The ZFS backend obviates the `ENROOT_NATIVE_OVERLAYFS=y` requirement that the `dir` backend imposes for `enroot load`.
+
+## Where the ZFS backend is used
+
+When `ENROOT_STORAGE_BACKEND=zfs`, ZFS substitutes for the existing storage code paths in three places. The overlayfs and `fuse-overlayfs` paths are not removed — they continue to serve the `dir` backend and any host without ZFS.
+
+| Subsystem | `dir` backend | `zfs` backend |
+| ------ | ------ | ------ |
+| `enroot create foo.sqsh` | `unsquashfs` into `<store>/<NAME>` | Extract once into `templates/<sha>`, `zfs clone templates/<sha>@pristine <user>/<NAME>`. |
+| `enroot start foo.sqsh` (ephemeral; no prior `create`) | `squashfuse` lower layer + overlay upper layer, with kernel `overlay` or `fuse-overlayfs` selected by `ENROOT_NATIVE_OVERLAYFS`. | Ensure template, `zfs clone @pristine` to a unique ephemeral name, `zfs destroy` on exit. |
+| `enroot load docker://` (fetch + create in one step) | Layer-stack via `enroot-mksquashovlfs` overlay; requires `ENROOT_NATIVE_OVERLAYFS=y`. | Stack Docker layers as a chain of ZFS datasets — for each layer in order, `zfs clone parent@done` produces a writable child, the layer tarball is extracted into it with whiteout handling, then `zfs snapshot @done`. The leaf snapshot becomes the template's `@pristine`. Mirrors Docker's own `zfs` storage driver. |
+
+`ENROOT_NATIVE_OVERLAYFS` keeps its current meaning when the backend is `dir`. When the backend is `zfs`, the knob is irrelevant for the three substituted paths above (overlay is not used), but it continues to control overlay choice for any code path that does not yet have a ZFS substitution.
+
+The `ENROOT_NATIVE_OVERLAYFS=y` precondition for `enroot load docker://` is **not required** when the ZFS backend is active — ZFS layer-stacking does not depend on kernel overlayfs.
+
+## Behavior change vs. today
+
+When `ENROOT_STORAGE_BACKEND=zfs`:
+
+- **`enroot remove`** no longer reclaims template storage immediately. Reclamation happens on the next `create` (cold sweep) or whenever the warm period expires under pressure. Sites that need eager reclamation should set `ENROOT_TEMPLATE_WARM_SECONDS=0`.
+- **Ephemeral `enroot start <image>`** uses a throwaway clone instead of `squashfuse + overlay`. Faster startup; ZFS pool sees brief dataset churn.
+- **`enroot load docker://`** does not require `ENROOT_NATIVE_OVERLAYFS=y`. The layer-stacking path is ZFS clones rather than `enroot-mksquashovlfs`.
+
+`WARM_SECONDS=0` and no quota collapses the template-cache design to refcount-on-remove behavior — equivalent in disk economics to today's `dir` backend, but with all the clone-on-create, ephemeral-start, and Docker-layer-stacking wins still active.
+
+When `ENROOT_STORAGE_BACKEND=dir` (the default), behavior is byte-for-byte identical to today.

--- a/enroot.in
+++ b/enroot.in
@@ -100,6 +100,7 @@ config::export ENROOT_REMAP_ROOT       false
 config::export ENROOT_BUNDLE_ALL       false
 config::export ENROOT_BUNDLE_CHECKSUM  false
 config::export ENROOT_FORCE_OVERRIDE   false
+config::export ENROOT_STORAGE_BACKEND  "dir"
 
 config::fini
 

--- a/enroot.in
+++ b/enroot.in
@@ -113,6 +113,7 @@ export ENROOT_VERSION="@version@"
 source "${ENROOT_LIBRARY_PATH}/common.sh"
 source "${ENROOT_LIBRARY_PATH}/docker.sh"
 source "${ENROOT_LIBRARY_PATH}/runtime.sh"
+source "${ENROOT_LIBRARY_PATH}/storage_zfs.sh"
 
 enroot::usage() {
     case "$1" in

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -391,8 +391,6 @@ runtime::exec() {
 runtime::create() {
     local image="$1" rootfs="$2"
 
-    common::checkcmd unsquashfs find
-
     # Resolve the container image path.
     if [ -z "${image}" ]; then
         common::err "Invalid argument"
@@ -405,14 +403,28 @@ runtime::create() {
         common::err "Invalid image format: ${image}"
     fi
 
-    # Resolve the container rootfs path.
+    # Resolve the container rootfs name.
     if [ -z "${rootfs}" ]; then
         rootfs=$(basename "${image%.sqsh}")
     fi
     if [[ "${rootfs}" == */* ]]; then
         common::err "Invalid argument: ${rootfs}"
     fi
-    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs}")
+
+    if zfs::enabled; then
+        runtime::_create_zfs "${image}" "${rootfs}"
+    else
+        runtime::_create_dir "${image}" "${rootfs}"
+    fi
+}
+
+runtime::_create_dir() {
+    local -r image="$1" rootfs_name="$2"
+    local rootfs
+
+    common::checkcmd unsquashfs find
+
+    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs_name}")
     if [ -e "${rootfs}" ]; then
         if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
             common::err "File already exists: ${rootfs}"
@@ -421,12 +433,21 @@ runtime::create() {
         fi
     fi
 
-    # Extract the container rootfs from the image.
     common::log INFO "Extracting squashfs filesystem..." NL
     # XXX: https://github.com/NVIDIA/enroot/issues/90
     [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
     unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" -user-xattrs -d "${rootfs}" "${image}" >&2
     common::fixperms "${rootfs}"
+}
+
+runtime::_create_zfs() {
+    local -r image="$1" rootfs_name="$2"
+    local sha template
+
+    zfs::checkenv
+    sha=$(zfs::image_sha256 "${image}")
+    template=$(zfs::ensure_template "${image}" "${sha}")
+    zfs::clone_container "${template}" "${rootfs_name}"
 }
 
 runtime::digest() {

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -617,26 +617,46 @@ runtime::list() {
 }
 
 runtime::remove() {
-    local rootfs="$1"
+    local rootfs_name="$1"
 
-    # Resolve the container rootfs path.
-    if [ -z "${rootfs}" ]; then
+    if [ -z "${rootfs_name}" ]; then
         common::err "Invalid argument"
     fi
-    if [[ "${rootfs}" == */* ]]; then
-        common::err "Invalid argument: ${rootfs}"
+    if [[ "${rootfs_name}" == */* ]]; then
+        common::err "Invalid argument: ${rootfs_name}"
     fi
-    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs}")
+
+    if zfs::enabled; then
+        runtime::_remove_zfs "${rootfs_name}"
+    else
+        runtime::_remove_dir "${rootfs_name}"
+    fi
+}
+
+runtime::_remove_dir() {
+    local -r rootfs_name="$1"
+    local rootfs
+    rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs_name}")
     if [ ! -d "${rootfs}" ]; then
         common::err "No such file or directory: ${rootfs}"
     fi
-
-    # Remove the rootfs specified after asking for confirmation.
     if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
         read -r -e -p "Do you really want to delete ${rootfs}? [y/N] "
     fi
     if [ -n "${ENROOT_FORCE_OVERRIDE-}" ] || [ "${REPLY}" = "y" ] || [ "${REPLY}" = "Y" ]; then
         common::rmall "${rootfs}"
+    fi
+}
+
+runtime::_remove_zfs() {
+    local -r rootfs_name="$1"
+    local rootfs
+    rootfs="${ENROOT_DATA_PATH}/${rootfs_name}"
+    if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+        read -r -e -p "Do you really want to delete ${rootfs}? [y/N] "
+    fi
+    if [ -n "${ENROOT_FORCE_OVERRIDE-}" ] || [ "${REPLY}" = "y" ] || [ "${REPLY}" = "Y" ]; then
+        zfs::destroy_container "${rootfs_name}"
     fi
 }
 

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -44,3 +44,50 @@ zfs::image_sha256() {
     local -r image="$1"
     sha256sum "${image}" | awk '{print $1}'
 }
+
+# Ensures a template dataset exists for the given image hash, extracting if needed.
+# Prints the template's full dataset name (e.g. tank/enroot/.templates/<sha>).
+# Atomic across concurrent callers via a per-hash .tmp dataset.
+zfs::ensure_template() {
+    local -r image="$1" sha="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r template="${store}/${zfs_template_subdir}/${sha}"
+    local -r tmp="${template}.tmp"
+    local -r snap="${template}@${zfs_pristine_snap}"
+    local mountpoint
+    local i timeout=600
+
+    # Fast path: template already exists with @pristine.
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Try to create the .tmp dataset atomically. Whoever wins is the extractor.
+    if zfs create -p "${tmp}" 2> /dev/null; then
+        # We won — extract.
+        mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
+        common::log INFO "Extracting squashfs filesystem into ZFS template..." NL
+        [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
+        unsquashfs ${TTY_OFF+-no-progress} -processors "${ENROOT_MAX_PROCESSORS}" \
+                   -user-xattrs -f -d "${mountpoint}" "${image}" >&2
+        common::fixperms "${mountpoint}"
+        zfs rename "${tmp}" "${template}"
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}"
+        printf "%s" "${template}"
+        return
+    fi
+
+    # Lost the race or stale .tmp from a crashed extractor. Wait for @pristine.
+    for ((i = 0; i < timeout; i++)); do
+        if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+            printf "%s" "${template}"
+            return
+        fi
+        sleep 1
+    done
+
+    common::err "Timed out waiting for template extraction: ${template}. \
+A previous extractor may have crashed; remove ${tmp} manually and retry."
+}

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -1,0 +1,40 @@
+# Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[ -v _STORAGE_ZFS_SH_ ] && return || readonly _STORAGE_ZFS_SH_=1
+
+source "${ENROOT_LIBRARY_PATH}/common.sh"
+
+readonly zfs_template_subdir=".templates"
+readonly zfs_pristine_snap="pristine"
+
+# Returns 0 if the ZFS storage backend is configured, 1 otherwise.
+zfs::enabled() {
+    [ "${ENROOT_STORAGE_BACKEND-dir}" = "zfs" ]
+}
+
+# Resolves and prints the ZFS dataset name backing ${ENROOT_DATA_PATH}.
+# Errors if the path is not a ZFS dataset mountpoint.
+zfs::store_dataset() {
+    local dataset
+    dataset=$(zfs list -H -o name "${ENROOT_DATA_PATH}" 2> /dev/null) || \
+        common::err "ENROOT_DATA_PATH (${ENROOT_DATA_PATH}) is not a ZFS dataset mountpoint"
+    printf "%s" "${dataset}"
+}
+
+# Errors with a clear message if zfs(8) is unavailable or the store is not on ZFS.
+zfs::checkenv() {
+    common::checkcmd zfs sha256sum
+    zfs::store_dataset > /dev/null
+}

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -91,3 +91,20 @@ zfs::ensure_template() {
     common::err "Timed out waiting for template extraction: ${template}. \
 A previous extractor may have crashed; remove ${tmp} manually and retry."
 }
+
+# Clones the @pristine snapshot of a template into a named user container.
+# Errors if the target name is already taken.
+zfs::clone_container() {
+    local -r template="$1" name="$2"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+
+    if zfs list -H "${target}" > /dev/null 2>&1; then
+        if [ -z "${ENROOT_FORCE_OVERRIDE-}" ]; then
+            common::err "Container already exists: ${name}"
+        fi
+        zfs destroy -r "${target}"
+    fi
+
+    zfs clone "${template}@${zfs_pristine_snap}" "${target}"
+}

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -38,3 +38,9 @@ zfs::checkenv() {
     common::checkcmd zfs sha256sum
     zfs::store_dataset > /dev/null
 }
+
+# Computes the sha256 of a squashfs image file. Used as the template cache key.
+zfs::image_sha256() {
+    local -r image="$1"
+    sha256sum "${image}" | awk '{print $1}'
+}

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -108,3 +108,28 @@ zfs::clone_container() {
 
     zfs clone "${template}@${zfs_pristine_snap}" "${target}"
 }
+
+# Destroys a user container and its template if no other clones reference the
+# template's @pristine snapshot. (Refcount-only behavior; warm-period eviction
+# is added in plan B.)
+zfs::destroy_container() {
+    local -r name="$1"
+    local -r store=$(zfs::store_dataset)
+    local -r target="${store}/${name}"
+    local origin
+
+    if ! zfs list -H "${target}" > /dev/null 2>&1; then
+        common::err "No such container: ${name}"
+    fi
+
+    origin=$(zfs get -H -o value origin "${target}")
+    zfs destroy "${target}"
+
+    # Try to destroy the origin's template if no other clones remain.
+    # 'zfs destroy' on a snapshot with clones fails harmlessly; we attempt and ignore.
+    if [ -n "${origin}" ] && [ "${origin}" != "-" ]; then
+        local template="${origin%@*}"
+        zfs destroy "${origin}" 2> /dev/null && \
+            zfs destroy "${template}" 2> /dev/null || :
+    fi
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `ENROOT_STORAGE_BACKEND=zfs` storage driver that replaces `unsquashfs`-per-create with extract-once-then-`zfs clone`. First create of a given image pays full extraction cost; subsequent creates from the same image are near-instant clones whose disk cost is only the diff from the shared template. Default `dir` backend is byte-for-byte unchanged.

This is the first of six plans (A-F) for the ZFS backend, each landing as its own PR. See [`doc/plans/README.md`](../blob/feature/zfs-foundation/doc/plans/README.md) for the full landing order.

**Scope (Plan A):**
- New module `src/storage_zfs.sh` with `zfs::` namespace helpers.
- Backend dispatch in `runtime::create` and `runtime::remove` on `${ENROOT_STORAGE_BACKEND}`.
- Templates at `${ENROOT_DATA_PATH}/.templates/<sha256>` with `@pristine` snapshot.
- User clones at `${ENROOT_DATA_PATH}/<NAME>` (`zfs clone` of `@pristine`).
- Refcount-only template lifecycle: template destroyed when last clone goes away.
- Atomic concurrent-extraction via `<sha>.tmp` dataset lock + bounded snapshot wait.
- Design captured in [`doc/zfs.md`](../blob/feature/zfs-foundation/doc/zfs.md).

**Out of scope (later plans):** template warm/cold lifecycle (B), `.zfs` file format (C), `zfs://` URI transport (D), ephemeral `start <image>` ZFS path (E), Docker layer-stacking on ZFS (F).

## Test Plan

This codebase has no automated test suite; verification is manual. Plan A's tasks were executed against a loopback ZFS pool on Linux 6.12.75 (aarch64), zfs-2.4.1; all verifications pass.

- [x] `bash -n src/storage_zfs.sh` clean
- [x] `make` builds with `src/storage_zfs.sh` in SRCS
- [x] `enroot info` reports `ENROOT_STORAGE_BACKEND=zfs` when set
- [x] `dir` backend regression: `enroot create alpine.sqsh` then `enroot remove` works as before
- [x] ZFS create extracts template + clones; second create from same `.sqsh` is `<100ms` (no extraction log)
- [x] Concurrent `enroot create`s race-safe: 4 concurrent extractions yield exactly one template
- [x] ZFS remove keeps template alive while sibling clones exist; reaps template when last clone removed
- [x] `enroot list` enumerates ZFS clones; `.templates` dotfile is hidden (no code change needed)
- [x] `enroot start <name> /bin/echo hello` runs against ZFS clone

**Linux mount(2) caveat:** ZFS delegation on Linux still requires `CAP_SYS_ADMIN` for the kernel `mount(2)` syscall. Practical workaround documented in `doc/zfs.md`: run `enroot create` privileged (sudo); `start`/`exec`/`remove` work unprivileged.