### PR TITLE
Plan E: ZFS ephemeral start path

### DIFF
--- a/doc/plans/2026-04-29-zfs-e-ephemeral-start.md
+++ b/doc/plans/2026-04-29-zfs-e-ephemeral-start.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** When the user runs `enroot start foo.sqsh` (no prior `create` — the image path is given directly), and `ENROOT_STORAGE_BACKEND=zfs`, substitute the existing `squashfuse + overlayfs` ephemeral mount with `ensure_template + zfs clone` to a unique throwaway dataset that is destroyed when the container exits. Existing behavior on the `dir` backend, and on non-ZFS hosts, is unchanged.
+**Goal:** When the user runs `enroot start foo.sqsh` (no prior `create` — the image path is given directly), and `ENROOT_STORAGE_BACKEND=zfs`, substitute the existing `squashfuse + overlayfs` ephemeral mount with `ensure_template + zfs clone` to a unique throwaway dataset that is destroyed when the container exits. Existing behavior on the `dir` backend, and on non-ZFS hosts, is unchanged. The original `exec enroot-nsenter ...` chain is preserved end-to-end, so PID semantics, signal forwarding, and `enroot exec PID` are unaffected.
 
-**Architecture:** Branch in `runtime::_mount_rootfs` (`src/runtime.sh:174-211`). On the ZFS path, the function instead arranges for an ephemeral clone, returns its mountpoint as the new `_rootfs`, and registers a cleanup hook so the clone is destroyed even if the parent process is killed. The fuse-shim machinery is bypassed entirely on this path.
+**Architecture:** The clone is created in `runtime::start` *before* the user-namespace transition, because `zfs list` cannot enumerate datasets from inside a Linux user namespace (zfs-2.4.x's ioctl handlers gate dataset visibility on `current_user_ns() == &init_user_ns`; no module parameter or capability changes this on current OpenZFS). Cleanup is handled by a small subshell ("zfs-eph-shim") modeled on the existing `runtime::_mount_rootfs_shim` pattern: forked into its own process group via `set -m`, parked with `SIGSTOP`, and triggered to run `zfs::ephemeral_destroy` via the kernel's orphaned-process-group `SIGHUP` rule when the parent's exec chain (`enroot-nsenter` → bash → `enroot-switchroot` → container) exits. The original `exec enroot-nsenter ...` line is unchanged. The container then sees the clone's mountpoint as a directory rootfs and the existing directory-rootfs path in `runtime::_start` operates on it identically to a `dir`-backend named container.
 
 **Depends on:** Plan A.
 
@@ -14,9 +14,11 @@
 
 ## Files
 
-- **Modify:** `src/runtime.sh:174-211` (`runtime::_mount_rootfs`).
-- **Modify:** `src/runtime.sh:213-282` (`runtime::_start`) — register cleanup.
-- **Modify:** `src/storage_zfs.sh` — add `zfs::ephemeral_clone`, `zfs::ephemeral_destroy`.
+- **Modify:** `src/runtime.sh` — `source storage_zfs.sh` near the top (so `zfs::*` is available in the `BASH_ENV`-loaded subshell after nsenter); add a ZFS branch with the cleanup shim near the end of `runtime::start`.
+- **Modify:** `src/storage_zfs.sh` — add `zfs::ephemeral_clone` and `zfs::ephemeral_destroy`.
+- **Modify:** `doc/zfs.md` — status note + Linux user-namespace caveat.
+
+`runtime::_mount_rootfs` (squashfuse + overlay path) is **not** modified — that path continues to serve non-ZFS hosts and the `dir` backend.
 
 ---
 
@@ -33,9 +35,10 @@ Append to `src/storage_zfs.sh`:
 readonly zfs_ephemeral_subdir=".ephemeral"
 
 # Creates an ephemeral clone of the template for the given image and prints its
-# mountpoint. The clone name embeds the host PID for uniqueness and so the
-# cleanup hook can find it. The container is intended to be torn down when the
-# enroot process exits.
+# clone dataset name and mountpoint (tab-separated). The clone name embeds the
+# host PID for uniqueness so concurrent enroot processes don't collide and so
+# the cleanup hook can find the right clone. Intended to be torn down via
+# zfs::ephemeral_destroy when the enroot process exits.
 zfs::ephemeral_clone() {
     local -r image="$1"
     local -r store=$(zfs::store_dataset)
@@ -61,21 +64,30 @@ zfs::ephemeral_destroy() {
 }
 ```
 
+Also add the new subdir constant alongside the existing template constants near the top of the file:
+
+```bash
+readonly zfs_ephemeral_subdir=".ephemeral"
+```
+
 - [ ] **Step 1.2: Verify standalone**
 
 ```sh
+make prefix=/usr DESTDIR=/tmp/enroot install
+sudo ENROOT_LIBRARY_PATH=/tmp/enroot/usr/lib/enroot \
+     ENROOT_DATA_PATH=/srv/enroot/$USER \
+     ENROOT_STORAGE_BACKEND=zfs ENROOT_MAX_PROCESSORS=2 \
 bash -c 'source ${ENROOT_LIBRARY_PATH}/common.sh
          source ${ENROOT_LIBRARY_PATH}/storage_zfs.sh
-         out=$(zfs::ephemeral_clone alpine.sqsh)
-         echo "got: ${out}"
+         out=$(zfs::ephemeral_clone /tmp/alpine.sqsh)
          clone="${out%%	*}"
          mp="${out##*	}"
-         ls "${mp}/etc/os-release" && echo OK
-         zfs::ephemeral_destroy "${clone}"
-         zfs list | grep -q ephemeral || echo "cleaned"'
+         ls "${mp}/etc/os-release" && echo "rootfs OK"
+         zfs::ephemeral_destroy "${clone}"'
+zfs list -t all | grep '\.ephemeral/[0-9]' && echo "BAD: clone leaked" || echo "OK: cleaned"
 ```
 
-Expected: `OK` and `cleaned`.
+Expected: `rootfs OK` and `OK: cleaned`.
 
 - [ ] **Step 1.3: Commit**
 
@@ -86,172 +98,208 @@ git commit -s -m "Add zfs::ephemeral_clone and zfs::ephemeral_destroy"
 
 ---
 
-### Task 2: Branch `runtime::_mount_rootfs` on backend
+### Task 2: Wire ephemeral lifecycle into `runtime::start`
 
 **Files:**
-- Modify: `src/runtime.sh:174-211` (`runtime::_mount_rootfs`)
+- Modify: `src/runtime.sh` — add `source storage_zfs.sh` near the top; add ZFS branch with cleanup shim before the existing `exec enroot-nsenter ...` line in `runtime::start`.
 
-- [ ] **Step 2.1: Add a ZFS branch at the top of the function**
+The clone must be created before `enroot-nsenter --user`. The cleanup must survive the `exec` chain. We solve both with a small subshell forked into its own process group, parked with `SIGSTOP`, that the kernel will deliver `SIGHUP+SIGCONT` to once its process group is orphaned (i.e. the moment the parent's container chain exits, including under `kill -9`). This mirrors `runtime::_mount_rootfs_shim` (`src/runtime.sh:141-172`).
 
-In `src/runtime.sh:174`, change:
+- [ ] **Step 2.1: Source `storage_zfs.sh` from `runtime.sh`**
+
+After Plan A, `runtime.sh` sources only `common.sh` at the top. Inside `runtime::start`, the script `exec`s a fresh bash via `enroot-nsenter` that loads `runtime.sh` via `BASH_ENV`. That fresh bash needs `zfs::*` symbols available even though it never runs through `enroot.in`'s top-level source chain.
+
+In `src/runtime.sh`, find:
 
 ```bash
-runtime::_mount_rootfs() {
-    local -r image="$1" rootfs="$2"
-    local pid=0 rv=0
+source "${ENROOT_LIBRARY_PATH}/common.sh"
 
-    common::checkcmd squashfuse mountpoint
-    if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
-        common::checkcmd fuse-overlayfs
-    fi
-    ...
+readonly hook_dirs=(...)
 ```
 
-to:
+and change it to:
 
 ```bash
-runtime::_mount_rootfs() {
-    local -r image="$1" rootfs="$2"
-    local pid=0 rv=0
+source "${ENROOT_LIBRARY_PATH}/common.sh"
+source "${ENROOT_LIBRARY_PATH}/storage_zfs.sh"
 
-    if zfs::enabled; then
-        runtime::_mount_rootfs_zfs "${image}" "${rootfs}"
-        return
-    fi
-
-    common::checkcmd squashfuse mountpoint
-    if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
-        common::checkcmd fuse-overlayfs
-    fi
-    ...
+readonly hook_dirs=(...)
 ```
 
-(Leave the existing body intact below the new branch — that path is still used on non-ZFS hosts and on the `dir` backend.)
+- [ ] **Step 2.2: Add the ZFS branch with shim to `runtime::start`**
 
-- [ ] **Step 2.2: Add `runtime::_mount_rootfs_zfs`**
-
-Append a new function to `src/runtime.sh` (after `runtime::_mount_rootfs`):
+In `src/runtime.sh`, locate `runtime::start`. Find the block:
 
 ```bash
-runtime::_mount_rootfs_zfs() {
-    local -r image="$1" rootfs="$2"
-    local out clone mountpoint
+    # Check if we're running unprivileged.
+    if [ -z "${ENROOT_ALLOW_SUPERUSER-}" ] || [ "${EUID}" -ne 0 ]; then
+        unpriv=y
+    fi
 
-    zfs::checkenv
-
-    out=$(zfs::ephemeral_clone "${image}")
-    clone="${out%%$'\t'*}"
-    mountpoint="${out##*$'\t'}"
-
-    # Make the ephemeral clone visible at the canonical rootfs path the caller expects.
-    # The caller will bind-mount and pivot from this path; we redirect by bind-mounting
-    # the clone's mountpoint onto the placeholder rootfs.
-    cat <<- EOF | enroot-mount -
-	${mountpoint} ${rootfs} none rbind
-	EOF
-
-    # Register cleanup. Stash the clone name in a runtime file so the parent shell
-    # can destroy it after the container exits (see runtime::_start).
-    printf "%s\n" "${clone}" > "${ENROOT_RUNTIME_PATH}/zfs_ephemeral"
+    # Create new namespaces and start the container.
+    export BASH_ENV="${BASH_SOURCE[0]}"
+    exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
+      "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
+      'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
 }
 ```
 
-- [ ] **Step 2.3: Commit**
-
-```sh
-git add src/runtime.sh
-git commit -s -m "Branch runtime::_mount_rootfs on ZFS backend for ephemeral starts"
-```
-
----
-
-### Task 3: Wire ephemeral cleanup in `runtime::_start`
-
-**Files:**
-- Modify: `src/runtime.sh:213-282` (`runtime::_start`)
-
-- [ ] **Step 3.1: Add a trap that destroys the ephemeral clone**
-
-In `runtime::_start`, locate the existing `trap` setup or the area near the top of the function. Add:
+Insert the ZFS branch *between* the `unpriv=y` block and the `exec` line:
 
 ```bash
-    # If we created an ephemeral ZFS clone in _mount_rootfs, destroy it on exit.
-    if [ -f "${ENROOT_RUNTIME_PATH}/zfs_ephemeral" ]; then
-        local zfs_ephemeral_clone
-        zfs_ephemeral_clone=$(< "${ENROOT_RUNTIME_PATH}/zfs_ephemeral")
-        trap 'zfs::ephemeral_destroy "${zfs_ephemeral_clone}"' EXIT
+    # Check if we're running unprivileged.
+    if [ -z "${ENROOT_ALLOW_SUPERUSER-}" ] || [ "${EUID}" -ne 0 ]; then
+        unpriv=y
     fi
+
+    # ZFS backend: when starting from an image file, clone the template into an
+    # ephemeral dataset BEFORE entering the user namespace (zfs(8) cannot
+    # enumerate datasets from inside a userns) and fork a shim into its own
+    # process group to destroy the clone when the container exits. The shim
+    # mirrors runtime::_mount_rootfs_shim's orphaned-process-group cleanup
+    # pattern: it parks itself with SIGSTOP, gets SIGHUP'd by the kernel once
+    # this shell's exec'd container chain exits, and then runs zfs destroy.
+    if zfs::enabled && [ -f "${rootfs}" ]; then
+        local _zfs_eph_out _zfs_eph_clone _zfs_eph_mountpoint _zfs_eph_pid _zfs_eph_rv=0
+        _zfs_eph_out=$(zfs::ephemeral_clone "${rootfs}")
+        _zfs_eph_clone="${_zfs_eph_out%%$'\t'*}"
+        _zfs_eph_mountpoint="${_zfs_eph_out##*$'\t'}"
+
+        set -m
+        (
+            exec -a zfs-eph-shim "${BASH}" <<- EOF
+		$(declare -f zfs::ephemeral_destroy common::log common::fmt)
+		runtime::_zfs_ephemeral_shim() {
+		    trap "zfs::ephemeral_destroy '${_zfs_eph_clone}'; exit 0" SIGHUP
+		    kill -STOP \$\$
+		}
+		runtime::_zfs_ephemeral_shim
+		EOF
+        ) > /dev/null 2>&1 & _zfs_eph_pid=$!
+
+        # Wait for the shim to park itself (exit code 128+SIGSTOP=147).
+        wait "${_zfs_eph_pid}" 2> /dev/null || _zfs_eph_rv=$?
+        set +m
+        if ((_zfs_eph_rv != 128 + 19)); then
+            zfs::ephemeral_destroy "${_zfs_eph_clone}"
+            common::err "ZFS ephemeral cleanup shim failed to start (rv=${_zfs_eph_rv})"
+        fi
+        disown "${_zfs_eph_pid}" > /dev/null 2>&1
+
+        rootfs="${_zfs_eph_mountpoint}"
+    fi
+
+    # Create new namespaces and start the container.
+    export BASH_ENV="${BASH_SOURCE[0]}"
+    exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
+      "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
+      'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
+}
 ```
 
-Place this after the existing tmpfs setup (around line 226), but before the rootfs mount block at line 232.
+The `exec enroot-nsenter ...` line is unchanged — the shim runs alongside, not instead of, the original chain.
 
-- [ ] **Step 3.2: Verify ephemeral lifecycle end-to-end**
+- [ ] **Step 2.3: Verify ephemeral lifecycle end-to-end**
 
 ```sh
-export ENROOT_STORAGE_BACKEND=zfs
-export ENROOT_DATA_PATH=/srv/enroot/$USER
-zfs list -t all | grep ephemeral || echo "none yet"
-/tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/echo hello
-zfs list -t all | grep ephemeral || echo "cleaned"
+make prefix=/usr DESTDIR=/tmp/enroot install
+zfs list -t all -r tank/enroot/$USER/.ephemeral 2>&1 | grep '/[0-9]' || echo "none yet"
+sudo PATH=/tmp/enroot/usr/bin:$PATH ENROOT_STORAGE_BACKEND=zfs ENROOT_DATA_PATH=/srv/enroot/$USER \
+  /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/echo hello
+zfs list -t all -r tank/enroot/$USER/.ephemeral 2>&1 | grep '/[0-9]' && echo "BAD: leaked" || echo "OK: cleaned"
 ```
 
-Expected: first check prints `none yet`; the start prints `hello`; final check prints `cleaned`.
+Expected: first probe `none yet`; start prints `hello`; final probe `OK: cleaned`.
 
-- [ ] **Step 3.3: Verify the template stays warm across ephemeral starts**
+- [ ] **Step 2.4: Verify the template stays warm across ephemeral starts**
 
 ```sh
-# First start: extract.
-time /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
-# Second start: should be fast (template already cached).
-time /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
-zfs list -t all -r tank/enroot/$USER/.templates | head
+sudo PATH=/tmp/enroot/usr/bin:$PATH ENROOT_STORAGE_BACKEND=zfs ENROOT_DATA_PATH=/srv/enroot/$USER \
+  bash -c 'time /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/true'
 ```
 
-Expected: second invocation noticeably faster; template persists.
+Expected: completes in well under a second; no "Extracting squashfs filesystem" log line on the second invocation.
 
-- [ ] **Step 3.4: Verify `dir` backend ephemeral start still uses overlayfs**
+- [ ] **Step 2.5: Verify `dir` backend ephemeral start still uses overlayfs**
 
 ```sh
 unset ENROOT_STORAGE_BACKEND
-export ENROOT_DATA_PATH=$HOME/.local/share/enroot
-/tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/echo hello
+PATH=/tmp/enroot/usr/bin:$PATH ENROOT_DATA_PATH=$HOME/.local/share/enroot ENROOT_NATIVE_OVERLAYFS=y \
+  /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/echo dir-backend-ok
 ```
 
-Expected: prints `hello`. Squashfuse + overlayfs path was used (no ZFS calls).
+Expected: prints `dir-backend-ok`. Squashfuse + overlay path was used; no ZFS calls.
 
-- [ ] **Step 3.5: Commit**
+- [ ] **Step 2.6: Verify `enroot exec PID` against an ephemeral container**
+
+This is the headline reason for the shim approach over a no-exec parent.
+
+```sh
+sudo PATH=/tmp/enroot/usr/bin:$PATH ENROOT_STORAGE_BACKEND=zfs ENROOT_DATA_PATH=/srv/enroot/$USER \
+  /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/sleep 30 &
+SP=$!; sleep 2
+ENROOT_PID=$(pgrep -P $(pgrep -f '^sudo.*enroot start /tmp/alpine'))
+ps -p ${ENROOT_PID} -o pid,comm
+sudo PATH=/tmp/enroot/usr/bin:$PATH /tmp/enroot/usr/bin/enroot exec ${ENROOT_PID} /bin/echo "exec-into-PID-works"
+sudo kill -9 ${ENROOT_PID}; wait $SP 2>/dev/null
+```
+
+Expected: `ps` shows `sleep` (the container's leaf process), `enroot exec` prints `exec-into-PID-works`, no ephemeral leftovers afterwards.
+
+- [ ] **Step 2.7: Verify `kill -9` of the container does not leak**
+
+```sh
+sudo PATH=/tmp/enroot/usr/bin:$PATH ENROOT_STORAGE_BACKEND=zfs ENROOT_DATA_PATH=/srv/enroot/$USER \
+  /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/sleep 60 &
+SP=$!; sleep 2
+CONTAINER_PID=$(pgrep -f '^/bin/sleep 60$' | head -1)
+sudo kill -9 "${CONTAINER_PID}"
+wait $SP 2>/dev/null; sleep 2
+zfs list -t all -r tank/enroot/$USER/.ephemeral | grep '/[0-9]' && echo "leaked" || echo "OK: cleaned"
+```
+
+Expected: `OK: cleaned` — the orphan-SIGHUP rule fires the shim's cleanup even on hard kill.
+
+- [ ] **Step 2.8: Commit**
 
 ```sh
 git add src/runtime.sh
-git commit -s -m "Add ephemeral ZFS clone cleanup on container exit"
+git commit -s -m "Wire ephemeral ZFS clone setup and cleanup shim into runtime::start"
 ```
 
 ---
 
-### Task 4: Document Plan E as implemented
+### Task 3: Document Plan E as implemented
 
 **Files:**
 - Modify: `doc/zfs.md`
 
-- [ ] **Step 4.1: Update status note**
+- [ ] **Step 3.1: Update status note**
 
-Update `doc/zfs.md` to mark Plan E (ephemeral start ZFS path) as landed.
+In `doc/zfs.md`, update the lead paragraph to mark Plans A and E as implemented.
 
-- [ ] **Step 4.2: End-to-end smoke**
+- [ ] **Step 3.2: Document the user-namespace caveat**
+
+Add a paragraph near the existing Linux mount(2) caveat in the admin setup section describing why ZFS work happens before `enroot-nsenter --user` and how the shim handles cleanup. Suggested wording:
+
+> **Linux user-namespace caveat:** `zfs list` cannot enumerate datasets from inside a Linux user namespace — even when their mount entries are visible — so any ZFS work must happen *before* `enroot-nsenter --user`. For ephemeral `enroot start <image>`, the ephemeral clone is created in `runtime::start` outside the namespace; cleanup is handled by a small `zfs-eph-shim` subshell that mirrors the existing `runtime::_mount_rootfs_shim` pattern — forked into its own process group, parked with `SIGSTOP`, and triggered to `zfs destroy` via the kernel's orphaned-process-group `SIGHUP` rule when the container's exec chain exits. The original `exec enroot-nsenter ...` chain is preserved, so PID semantics, signal forwarding, and `enroot exec PID` all work identically to the `dir` backend.
+
+- [ ] **Step 3.3: End-to-end smoke (5x ephemeral loop)**
 
 ```sh
-export ENROOT_STORAGE_BACKEND=zfs
-zfs list -t all -r tank/enroot/$USER | wc -l
+before=$(zfs list -H -t all -r tank/enroot/$USER/.ephemeral 2>/dev/null | wc -l)
 for i in 1 2 3 4 5; do
-    /tmp/enroot/usr/bin/enroot start alpine.sqsh /bin/true
+    sudo PATH=/tmp/enroot/usr/bin:$PATH ENROOT_STORAGE_BACKEND=zfs ENROOT_DATA_PATH=/srv/enroot/$USER \
+      /tmp/enroot/usr/bin/enroot start /tmp/alpine.sqsh /bin/true
 done
-zfs list -t all -r tank/enroot/$USER | wc -l   # should be the same as before — only the warm template, no ephemeral leftovers
-zfs list -t all -r tank/enroot/$USER | grep ephemeral && echo BAD || echo OK
+after=$(zfs list -H -t all -r tank/enroot/$USER/.ephemeral 2>/dev/null | wc -l)
+echo "before: ${before}, after: ${after}"
+zfs list -t all -r tank/enroot/$USER/.ephemeral | grep '/[0-9]' && echo "BAD" || echo "OK"
 ```
 
-Expected: `OK`.
+Expected: `OK` — `before == after` (or +1 for the cache parent appearing on first run); no ephemeral subdataset leftovers.
 
-- [ ] **Step 4.3: Commit**
+- [ ] **Step 3.4: Commit**
 
 ```sh
 git add doc/zfs.md
@@ -262,14 +310,15 @@ git commit -s -m "Mark Plan E (ephemeral start ZFS path) as implemented"
 
 ## Self-review checklist
 
-- [x] Spec coverage: ZFS path for ephemeral `start <image>` (T2, T3); cleanup on exit (T3.1); template-cache reuse across ephemeral starts (T3.3); non-ZFS path untouched (T2.1 leaves the original block intact below the branch; T3.4 verifies).
-- [x] Type consistency: `zfs::ephemeral_clone`, `zfs::ephemeral_destroy` from T1 are referenced in T2, T3.
+- [x] Spec coverage: ZFS path for ephemeral `start <image>` (T2.2), cleanup on container exit (T2.2 shim), template-cache reuse across ephemeral starts (T2.4 verifies), non-ZFS path untouched (T2.5 verifies, no edits to `runtime::_mount_rootfs`), `enroot exec PID` semantics preserved (T2.6 verifies), `kill -9` cleanup via SIGHUP (T2.7 verifies).
+- [x] Type consistency: `zfs::ephemeral_clone`, `zfs::ephemeral_destroy` defined in T1 are referenced from `runtime::start` and the inline `runtime::_zfs_ephemeral_shim` in T2.
 - [x] No placeholders.
 
 ## Known limitations
 
-- The ephemeral clone goes to a `.ephemeral/` subdataset rather than tmpfs; if the container writes huge amounts of throwaway data, it counts against the pool's quota until destroy. A future plan could bound this with a per-clone quota.
-- Cleanup is best-effort via shell trap. If `enroot` is hard-killed (`kill -9`), the ephemeral clone leaks until the next manual cleanup or process restart. A safety net (sweep `.ephemeral/` for clones whose PID is dead) could be added to `zfs::sweep_templates` if leaks become a problem in practice.
+- The ephemeral clone goes to a `.ephemeral/` subdataset rather than tmpfs; if the container writes huge amounts of throwaway data, it counts against the pool's quota until the shim destroys the clone.
+- Cleanup relies on the kernel's POSIX orphaned-process-group `SIGHUP` rule. If the host crashes (full power loss, hard reboot), the shim never runs and ephemeral clones persist across boot. A boot-time sweep of `.ephemeral/*` (destroy children whose embedded PID is no longer live) could be added to the admin recipe in `doc/zfs.md`. Out of scope for this plan.
+- The userns-vs-`zfs list` limitation is structural in OpenZFS as of zfs-2.4.x: dataset enumeration ioctls are not user-namespace-aware. No capability or module parameter (`zfs_admin_snapshot`, etc.) makes `zfs list` work inside the namespace on this version. If a future OpenZFS makes the iteration path userns-aware, the `runtime::start` placement of the clone could be reconsidered, but the cleanup shim would still be required because the `exec` chain (`enroot-nsenter` → bash → `enroot-switchroot` → container) leaves no surviving shell to fire an `EXIT` trap.
 
 ## Execution Handoff
 

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -1,6 +1,6 @@
 # ZFS storage backend
 
-This document describes an optional ZFS-aware mode for the enroot container store. **Plan A (foundation) is implemented**: `enroot create` and `enroot remove` use ZFS datasets when `ENROOT_STORAGE_BACKEND=zfs`. The remaining substitutions (template warm/cold lifecycle, `.zfs` file format, `zfs://` URI, ephemeral-start ZFS path, Docker layer stacking on ZFS) are tracked under `doc/plans/`. The default storage backend (plain directories under `ENROOT_DATA_PATH`) is unchanged and remains the only option on hosts without ZFS.
+This document describes an optional ZFS-aware mode for the enroot container store. **Plans A (foundation) and E (ephemeral start) are implemented**: `enroot create`, `enroot remove`, and ephemeral `enroot start <image>` all use ZFS datasets when `ENROOT_STORAGE_BACKEND=zfs`. The remaining substitutions (template warm/cold lifecycle, `.zfs` file format, `zfs://` URI, Docker layer stacking on ZFS) are tracked under `doc/plans/`. The default storage backend (plain directories under `ENROOT_DATA_PATH`) is unchanged and remains the only option on hosts without ZFS.
 
 ## Motivation
 
@@ -205,6 +205,8 @@ A site enabling the ZFS backend should:
    - **`fs.namespace.unprivileged_userns_clone=1` + per-user mount namespace.** A wrapper that enters a user namespace before `enroot create` lets the ZFS auto-mount succeed without root, at the cost of complexity and a small overhead.
 
    On hosts where the same operator runs `create` and `start`, the privileged-create approach is simpler and matches enroot's existing model where image conversion (`enroot import`/`enroot-aufs2ovlfs`) already requires elevated privileges.
+
+   **Linux user-namespace caveat:** `zfs list` cannot enumerate datasets from inside a Linux user namespace — even when their mount entries are visible — so any ZFS work must happen *before* `enroot-nsenter --user`. For ephemeral `enroot start <image>` (Plan E), the ephemeral clone is created in `runtime::start` outside the namespace, with a shell trap that destroys it on the parent process's exit. Implementation-internal, but worth knowing if you debug.
 
 4. **Configure `ENROOT_STORAGE_BACKEND=zfs`** in `enroot.conf` (or per-user). Set `ENROOT_DATA_PATH` to the mountpoint of `tank/enroot` (or per-user subdataset).
 

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -206,7 +206,7 @@ A site enabling the ZFS backend should:
 
    On hosts where the same operator runs `create` and `start`, the privileged-create approach is simpler and matches enroot's existing model where image conversion (`enroot import`/`enroot-aufs2ovlfs`) already requires elevated privileges.
 
-   **Linux user-namespace caveat:** `zfs list` cannot enumerate datasets from inside a Linux user namespace — even when their mount entries are visible — so any ZFS work must happen *before* `enroot-nsenter --user`. For ephemeral `enroot start <image>` (Plan E), the ephemeral clone is created in `runtime::start` outside the namespace, with a shell trap that destroys it on the parent process's exit. Implementation-internal, but worth knowing if you debug.
+   **Linux user-namespace caveat:** `zfs list` cannot enumerate datasets from inside a Linux user namespace — even when their mount entries are visible — so any ZFS work must happen *before* `enroot-nsenter --user`. For ephemeral `enroot start <image>` (Plan E), the ephemeral clone is created in `runtime::start` outside the namespace; cleanup is handled by a small "zfs-eph-shim" subshell that mirrors the existing `runtime::_mount_rootfs_shim` pattern — forked into its own process group, parked with `SIGSTOP`, and triggered to `zfs destroy` via the kernel's orphaned-process-group `SIGHUP` rule when the container's exec chain exits. The original `exec enroot-nsenter ...` chain is preserved, so PID semantics, signal forwarding, and `enroot exec PID` all work identically to the `dir` backend.
 
 4. **Configure `ENROOT_STORAGE_BACKEND=zfs`** in `enroot.conf` (or per-user). Set `ENROOT_DATA_PATH` to the mountpoint of `tank/enroot` (or per-user subdataset).
 

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -352,32 +352,46 @@ runtime::start() {
 
     # ZFS backend: when starting from an image file, clone the template into an
     # ephemeral dataset BEFORE entering the user namespace (zfs(8) cannot
-    # enumerate datasets from inside a userns), and arrange to destroy it on
-    # exit. The container then sees the clone's mountpoint as a directory rootfs
-    # and the rest of runtime::_start operates on it normally.
+    # enumerate datasets from inside a userns) and fork a shim into its own
+    # process group to destroy the clone when the container exits. The shim
+    # mirrors runtime::_mount_rootfs_shim's orphaned-process-group cleanup
+    # pattern: it parks itself with SIGSTOP, gets SIGHUP'd by the kernel once
+    # this shell's exec'd container chain exits, and then runs zfs destroy.
     if zfs::enabled && [ -f "${rootfs}" ]; then
-        local _zfs_ephemeral_out _zfs_ephemeral_clone _zfs_ephemeral_mountpoint
-        _zfs_ephemeral_out=$(zfs::ephemeral_clone "${rootfs}")
-        _zfs_ephemeral_clone="${_zfs_ephemeral_out%%$'\t'*}"
-        _zfs_ephemeral_mountpoint="${_zfs_ephemeral_out##*$'\t'}"
-        # Embed the clone name in the trap body so the value survives
-        # local-variable scope when the script exits.
-        trap "zfs::ephemeral_destroy '${_zfs_ephemeral_clone}'" EXIT
-        rootfs="${_zfs_ephemeral_mountpoint}"
+        local _zfs_eph_out _zfs_eph_clone _zfs_eph_mountpoint _zfs_eph_pid _zfs_eph_rv=0
+        _zfs_eph_out=$(zfs::ephemeral_clone "${rootfs}")
+        _zfs_eph_clone="${_zfs_eph_out%%$'\t'*}"
+        _zfs_eph_mountpoint="${_zfs_eph_out##*$'\t'}"
+
+        set -m
+        (
+            exec -a zfs-eph-shim "${BASH}" <<- EOF
+		$(declare -f zfs::ephemeral_destroy common::log common::fmt)
+		runtime::_zfs_ephemeral_shim() {
+		    trap "zfs::ephemeral_destroy '${_zfs_eph_clone}'; exit 0" SIGHUP
+		    kill -STOP \$\$
+		}
+		runtime::_zfs_ephemeral_shim
+		EOF
+        ) > /dev/null 2>&1 & _zfs_eph_pid=$!
+
+        # Wait for the shim to park itself (exit code 128+SIGSTOP=147).
+        wait "${_zfs_eph_pid}" 2> /dev/null || _zfs_eph_rv=$?
+        set +m
+        if ((_zfs_eph_rv != 128 + 19)); then
+            zfs::ephemeral_destroy "${_zfs_eph_clone}"
+            common::err "ZFS ephemeral cleanup shim failed to start (rv=${_zfs_eph_rv})"
+        fi
+        disown "${_zfs_eph_pid}" > /dev/null 2>&1
+
+        rootfs="${_zfs_eph_mountpoint}"
     fi
 
     # Create new namespaces and start the container.
     export BASH_ENV="${BASH_SOURCE[0]}"
-    if [ -n "${_zfs_ephemeral_clone-}" ]; then
-        # Don't exec: we need our shell to live so the EXIT trap above fires.
-        enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
-          "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
-          'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
-    else
-        exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
-          "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
-          'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
-    fi
+    exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
+      "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
+      'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
 }
 
 runtime::exec() {

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -175,6 +175,11 @@ runtime::_mount_rootfs() {
     local -r image="$1" rootfs="$2"
     local pid=0 rv=0
 
+    if zfs::enabled; then
+        runtime::_mount_rootfs_zfs "${image}" "${rootfs}"
+        return
+    fi
+
     common::checkcmd squashfuse mountpoint
     if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
         common::checkcmd fuse-overlayfs
@@ -208,6 +213,27 @@ runtime::_mount_rootfs() {
     fi
     exec {fd}>&-
     disown "${pid}" > /dev/null 2>&1
+}
+
+runtime::_mount_rootfs_zfs() {
+    local -r image="$1" rootfs="$2"
+    local out clone mountpoint
+
+    zfs::checkenv
+
+    out=$(zfs::ephemeral_clone "${image}")
+    clone="${out%%$'\t'*}"
+    mountpoint="${out##*$'\t'}"
+
+    # Bind-mount the ephemeral clone's mountpoint over the placeholder rootfs
+    # path the caller already prepared, so the rest of runtime::_start operates
+    # on it identically to the squashfuse+overlay path.
+    cat <<- EOF | enroot-mount -
+	${mountpoint} ${rootfs} none rbind
+	EOF
+
+    # Stash the clone name so runtime::_start's cleanup trap can destroy it on exit.
+    printf "%s\n" "${clone}" > "${ENROOT_RUNTIME_PATH}/zfs_ephemeral"
 }
 
 runtime::_start() {

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 source "${ENROOT_LIBRARY_PATH}/common.sh"
+source "${ENROOT_LIBRARY_PATH}/storage_zfs.sh"
 
 readonly hook_dirs=("${ENROOT_SYSCONF_PATH}/hooks.d" "${ENROOT_CONFIG_PATH}/hooks.d")
 readonly mount_dirs=("${ENROOT_SYSCONF_PATH}/mounts.d" "${ENROOT_CONFIG_PATH}/mounts.d")
@@ -175,11 +176,6 @@ runtime::_mount_rootfs() {
     local -r image="$1" rootfs="$2"
     local pid=0 rv=0
 
-    if zfs::enabled; then
-        runtime::_mount_rootfs_zfs "${image}" "${rootfs}"
-        return
-    fi
-
     common::checkcmd squashfuse mountpoint
     if [ -z "${ENROOT_NATIVE_OVERLAYFS-}" ]; then
         common::checkcmd fuse-overlayfs
@@ -213,27 +209,6 @@ runtime::_mount_rootfs() {
     fi
     exec {fd}>&-
     disown "${pid}" > /dev/null 2>&1
-}
-
-runtime::_mount_rootfs_zfs() {
-    local -r image="$1" rootfs="$2"
-    local out clone mountpoint
-
-    zfs::checkenv
-
-    out=$(zfs::ephemeral_clone "${image}")
-    clone="${out%%$'\t'*}"
-    mountpoint="${out##*$'\t'}"
-
-    # Bind-mount the ephemeral clone's mountpoint over the placeholder rootfs
-    # path the caller already prepared, so the rest of runtime::_start operates
-    # on it identically to the squashfuse+overlay path.
-    cat <<- EOF | enroot-mount -
-	${mountpoint} ${rootfs} none rbind
-	EOF
-
-    # Stash the clone name so runtime::_start's cleanup trap can destroy it on exit.
-    printf "%s\n" "${clone}" > "${ENROOT_RUNTIME_PATH}/zfs_ephemeral"
 }
 
 runtime::_start() {
@@ -375,11 +350,34 @@ runtime::start() {
         unpriv=y
     fi
 
+    # ZFS backend: when starting from an image file, clone the template into an
+    # ephemeral dataset BEFORE entering the user namespace (zfs(8) cannot
+    # enumerate datasets from inside a userns), and arrange to destroy it on
+    # exit. The container then sees the clone's mountpoint as a directory rootfs
+    # and the rest of runtime::_start operates on it normally.
+    if zfs::enabled && [ -f "${rootfs}" ]; then
+        local _zfs_ephemeral_out _zfs_ephemeral_clone _zfs_ephemeral_mountpoint
+        _zfs_ephemeral_out=$(zfs::ephemeral_clone "${rootfs}")
+        _zfs_ephemeral_clone="${_zfs_ephemeral_out%%$'\t'*}"
+        _zfs_ephemeral_mountpoint="${_zfs_ephemeral_out##*$'\t'}"
+        # Embed the clone name in the trap body so the value survives
+        # local-variable scope when the script exits.
+        trap "zfs::ephemeral_destroy '${_zfs_ephemeral_clone}'" EXIT
+        rootfs="${_zfs_ephemeral_mountpoint}"
+    fi
+
     # Create new namespaces and start the container.
     export BASH_ENV="${BASH_SOURCE[0]}"
-    exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
-      "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
-      'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
+    if [ -n "${_zfs_ephemeral_clone-}" ]; then
+        # Don't exec: we need our shell to live so the EXIT trap above fires.
+        enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
+          "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
+          'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
+    else
+        exec enroot-nsenter ${unpriv:+--user} --mount ${ENROOT_REMAP_ROOT:+--remap-root} \
+          "${BASH}" --norc -o ${SHELLOPTS//:/ -o } -O ${BASHOPTS//:/ -O } -c \
+          'runtime::_start "$@"' "${config}" "${rootfs}" "${rc}" "${config}" "${mounts}" "${environ}" "$@"
+    fi
 }
 
 runtime::exec() {

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -18,6 +18,7 @@ source "${ENROOT_LIBRARY_PATH}/common.sh"
 
 readonly zfs_template_subdir=".templates"
 readonly zfs_pristine_snap="pristine"
+readonly zfs_ephemeral_subdir=".ephemeral"
 
 # Returns 0 if the ZFS storage backend is configured, 1 otherwise.
 zfs::enabled() {
@@ -132,4 +133,33 @@ zfs::destroy_container() {
         zfs destroy "${origin}" 2> /dev/null && \
             zfs destroy "${template}" 2> /dev/null || :
     fi
+}
+
+# Creates an ephemeral clone of the template for the given image and prints its
+# clone dataset name and mountpoint (tab-separated). The clone name embeds the
+# host PID for uniqueness so concurrent enroot processes don't collide and so
+# the cleanup hook can find the right clone. Intended to be torn down via
+# zfs::ephemeral_destroy when the enroot process exits.
+zfs::ephemeral_clone() {
+    local -r image="$1"
+    local -r store=$(zfs::store_dataset)
+    local sha template clone mountpoint
+
+    sha=$(zfs::image_sha256 "${image}")
+    template=$(zfs::ensure_template "${image}" "${sha}")
+
+    clone="${store}/${zfs_ephemeral_subdir}/${$}-${sha:0:12}"
+    zfs create -p "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
+    zfs clone "${template}@${zfs_pristine_snap}" "${clone}"
+    zfs set readonly=off "${clone}"
+
+    mountpoint=$(zfs get -H -o value mountpoint "${clone}")
+    printf "%s\t%s" "${clone}" "${mountpoint}"
+}
+
+# Destroys an ephemeral clone. Best-effort; intended for cleanup hooks.
+zfs::ephemeral_destroy() {
+    local -r clone="$1"
+    [ -z "${clone}" ] && return
+    zfs destroy "${clone}" 2> /dev/null || :
 }


### PR DESCRIPTION
## Summary

When `ENROOT_STORAGE_BACKEND=zfs`, `enroot start <image>` (no prior `create` — the image path is given directly) now uses an ephemeral ZFS clone instead of `squashfuse + overlayfs`. The clone is destroyed when the container exits.

Implements [Plan E](../blob/feature/zfs-e-ephemeral-start/doc/plans/2026-04-29-zfs-e-ephemeral-start.md). Builds on Plan A (#1).

## What changed

- `src/storage_zfs.sh` — added `zfs::ephemeral_clone` and `zfs::ephemeral_destroy` helpers; uses a `.ephemeral/` subdataset under `${ENROOT_DATA_PATH}` for the throwaway clones.
- `src/runtime.sh` — added `source storage_zfs.sh` near the top so `zfs::*` symbols are available in the nsenter'd subshell that loads `runtime.sh` via `BASH_ENV`.
- `src/runtime.sh` — added a ZFS branch in `runtime::start` that clones the template into `.ephemeral/<pid>-<sha>` and forks a small `zfs-eph-shim` subshell into its own process group. The shim mirrors the existing `runtime::_mount_rootfs_shim` pattern (`src/runtime.sh:141-172`): parked with `SIGSTOP`, triggered to `zfs destroy` by the kernel's orphaned-process-group `SIGHUP` rule when the container's exec chain exits — including on `kill -9`. The original `exec enroot-nsenter ...` line is unchanged.
- `doc/zfs.md` — status note flipped to "Plans A and E implemented"; documented the user-namespace ZFS limitation and the shim pattern.

## Why a shim and not an `EXIT` trap

The clone has to be created **before** `enroot-nsenter --user`, because `zfs list` cannot enumerate datasets from inside a Linux user namespace (zfs-2.4.x's ioctl handlers gate visibility on `init_user_ns`; no capability or module parameter changes this). Cleanup, in turn, has to happen on a process that survives the entire `exec` chain (`enroot-nsenter` → bash → `enroot-switchroot` → container/etc/rc); a trap inside `runtime::_start` would never fire because every shell in that chain is replaced by `exec`. The shim is the smallest piece that satisfies both constraints, and the codebase already uses the same pattern for `fuse-overlayfs` lifecycle, so it stays inside enroot's existing idioms. PID semantics, signal forwarding, and `enroot exec PID` are unaffected.

## Test Plan

Verified manually against a loopback ZFS pool on Linux 6.12.75 (aarch64), zfs-2.4.1, with a real `docker://alpine` image:

- [x] `enroot start /tmp/alpine.sqsh /bin/echo hello` → prints `hello`, no ephemeral leftovers
- [x] Subsequent ephemeral start completes in ~0.2s (template stays warm; no extraction)
- [x] `dir` backend ephemeral start (`unset ENROOT_STORAGE_BACKEND`, `ENROOT_NATIVE_OVERLAYFS=y`) still works via squashfuse + overlay; no regression
- [x] 5x ephemeral start loop: zero ephemeral leftovers in `zfs list`
- [x] `enroot exec PID` against a running ephemeral container prints output (PID points at the container's leaf process, not a wrapping shell)
- [x] `kill -9` of the container's leaf PID: shim cleans up the clone via the orphaned-process-group `SIGHUP` rule

## Known limitations

- The ephemeral clone goes to `.ephemeral/` rather than tmpfs; container writes count against the pool quota until the shim destroys the clone.
- If the host crashes (full power loss, hard reboot), the orphan-`SIGHUP` rule never fires and ephemeral clones persist across boot. Mitigation: a boot-time sweep of `.ephemeral/*` (destroy children whose embedded PID is no longer live) could be added to the admin recipe in `doc/zfs.md`. Out of scope for this PR.