### PR TITLE
enroot-zfs-mount helper: unprivileged ZFS for pyxis/Slurm (issue #9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,8 @@ $(error MUSL CC wrapper not found for $(CC))
 endif
 endif
 
+bin/enroot-zfs-mount: CPPFLAGS += -DSYSCONFDIR=\"$(sysconfdir)\"
+
 $(BIN) $(CONFIG): %: %.in
 	sed -e 's;@sysconfdir@;$(SYSCONFDIR);' \
 	    -e 's;@libdir@;$(LIBDIR);' \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ UTILS := bin/enroot-aufs2ovlfs    \
          bin/enroot-mksquashovlfs \
          bin/enroot-mount         \
          bin/enroot-switchroot    \
-         bin/enroot-nsenter
+         bin/enroot-nsenter       \
+         bin/enroot-zfs-mount
 
 CONFIGFILE := enroot.conf
 CONFIG := conf/$(CONFIGFILE)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIBDIR     = $(DESTDIR)$(libdir)/enroot
 SYSCONFDIR = $(DESTDIR)$(sysconfdir)/enroot
 DATADIR    = $(DESTDIR)$(datadir)/enroot
 
-VERSION       := 4.1.2.zfs.1
+VERSION       := 4.1.2.zfs.2
 PACKAGE       ?= enroot
 ARCH          ?= $(shell uname -m)
 DEBUG         ?=

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ distclean: clean
 setcap:
 	setcap cap_sys_admin+pe $(BINDIR)/enroot-mksquashovlfs
 	setcap cap_sys_admin,cap_mknod+pe $(BINDIR)/enroot-aufs2ovlfs
+	setcap cap_sys_admin+pe $(BINDIR)/enroot-zfs-mount
 
 deb: export DEBFULLNAME := $(USERNAME)
 deb: export DEBEMAIL    := $(EMAIL)

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -195,6 +195,48 @@ read_data_path(void)
         return (result);
 }
 
+/*
+ * Walks /proc/self/mounts looking for a "zfs" mount whose SOURCE is
+ * `dataset` (not whose mountpoint matches a path). Returns the current
+ * mountpoint path (malloc'd), or NULL if the dataset isn't mounted anywhere
+ * we can see.
+ */
+static char *
+find_current_mountpoint(const char *dataset)
+{
+        FILE *f;
+        char *line = NULL, *result = NULL;
+        size_t len = 0;
+        ssize_t n;
+
+        f = fopen("/proc/self/mounts", "r");
+        if (f == NULL)
+                err(EXIT_FAILURE, "cannot read /proc/self/mounts");
+
+        while ((n = getline(&line, &len, f)) != -1) {
+                char src[PATH_MAX], mp[PATH_MAX], type[64];
+
+                (void)n;
+
+                if (sscanf(line, "%4095s %4095s %63s", src, mp, type) != 3)
+                        continue;
+                if (strcmp(type, "zfs") != 0)
+                        continue;
+                if (strcmp(src, dataset) == 0) {
+                        result = strdup(mp);
+                        if (result == NULL) {
+                                free(line);
+                                fclose(f);
+                                err(EXIT_FAILURE, "strdup");
+                        }
+                        break;
+                }
+        }
+        free(line);
+        fclose(f);
+        return (result);
+}
+
 static void
 init_capabilities(void)
 {
@@ -227,6 +269,23 @@ do_mount(const char *source, const char *target, const char *fstype,
                 return (-1);
 
         rv = mount(source, target, fstype, flags, data);
+
+        CAP_CLR(&caps, effective, CAP_SYS_ADMIN);
+        if (capset(&caps.hdr, caps.data) < 0)
+                return (-1);
+        return (rv);
+}
+
+static int
+do_umount(const char *target, int flags)
+{
+        int rv;
+
+        CAP_SET(&caps, effective, CAP_SYS_ADMIN);
+        if (capset(&caps.hdr, caps.data) < 0)
+                return (-1);
+
+        rv = umount2(target, flags);
 
         CAP_CLR(&caps, effective, CAP_SYS_ADMIN);
         if (capset(&caps.hdr, caps.data) < 0)
@@ -281,8 +340,21 @@ main(int argc, char *argv[])
                 errx(EXIT_FAILURE, "dataset %s is not under %s", dataset, parent_ds);
 
         if (do_unmount) {
-                /* TODO Task 5 */
-                errx(EXIT_FAILURE, "unmount not implemented yet");
+                char *cur = find_current_mountpoint(dataset);
+                if (cur == NULL) {
+                        free(parent_ds);
+                        free(data_path);
+                        return (EXIT_SUCCESS);  /* not mounted; idempotent no-op */
+                }
+                if (!path_under(cur, data_path))
+                        errx(EXIT_FAILURE, "current mountpoint %s is not under %s",
+                             cur, data_path);
+                if (do_umount(cur, 0) < 0)
+                        err(EXIT_FAILURE, "umount %s", cur);
+                free(cur);
+                free(parent_ds);
+                free(data_path);
+                return (EXIT_SUCCESS);
         }
 
         char *mp = get_mountpoint(dataset);

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -16,6 +16,7 @@
 
 #define _GNU_SOURCE
 #include <err.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,6 +29,71 @@
 # define SYSCONFDIR "/usr/local/etc"
 #endif
 #define CONF_PATH SYSCONFDIR "/enroot/enroot.conf"
+
+/*
+ * Walks /proc/self/mounts looking for a "zfs" mount whose mountpoint covers
+ * `data_path` (i.e., is data_path itself or a path-component ancestor of it).
+ * Returns the longest-matching dataset name (malloc'd), or NULL if no zfs
+ * mount covers data_path.
+ */
+static char *
+resolve_parent_dataset(const char *data_path)
+{
+        FILE *f;
+        char *line = NULL, *best_src = NULL;
+        size_t len = 0, best_mp_len = 0, dp_len;
+        ssize_t n;
+
+        f = fopen("/proc/self/mounts", "r");
+        if (f == NULL)
+                err(EXIT_FAILURE, "cannot read /proc/self/mounts");
+
+        dp_len = strlen(data_path);
+
+        while ((n = getline(&line, &len, f)) != -1) {
+                char src[PATH_MAX], mp[PATH_MAX], type[64];
+                size_t mp_len;
+
+                if (sscanf(line, "%4095s %4095s %63s", src, mp, type) != 3)
+                        continue;
+                if (strcmp(type, "zfs") != 0)
+                        continue;
+
+                mp_len = strlen(mp);
+                /* mp must be data_path itself or a strict ancestor path. */
+                if (mp_len > dp_len)
+                        continue;
+                if (strncmp(mp, data_path, mp_len) != 0)
+                        continue;
+                /* Disallow false prefix matches (e.g., "/foo" vs "/foobar"); the
+                 * char in data_path right after mp must be '/' or end-of-string,
+                 * unless mp is "/" itself. */
+                if (mp_len > 1 && mp_len < dp_len && data_path[mp_len] != '/')
+                        continue;
+
+                if (mp_len > best_mp_len) {
+                        free(best_src);
+                        best_src = strdup(src);
+                        if (best_src == NULL)
+                                err(EXIT_FAILURE, "strdup");
+                        best_mp_len = mp_len;
+                }
+        }
+        free(line);
+        fclose(f);
+        return (best_src);
+}
+
+/* Returns true iff dataset is exactly parent or a child path under parent/. */
+static bool
+dataset_under(const char *dataset, const char *parent)
+{
+        size_t pl = strlen(parent);
+
+        if (strncmp(dataset, parent, pl) != 0)
+                return (false);
+        return (dataset[pl] == '\0' || dataset[pl] == '/');
+}
 
 static struct capabilities_v3 caps;
 
@@ -162,7 +228,15 @@ main(int argc, char *argv[])
         char *data_path = read_data_path();
         if (data_path == NULL)
                 errx(EXIT_FAILURE, "ENROOT_DATA_PATH is not set in %s", CONF_PATH);
-        /* TODO Task 3-4: validate the dataset is under data_path's parent dataset */
+
+        char *parent_ds = resolve_parent_dataset(data_path);
+        if (parent_ds == NULL)
+                errx(EXIT_FAILURE, "no ZFS dataset is mounted at or above %s", data_path);
+
+        if (!dataset_under(dataset, parent_ds))
+                errx(EXIT_FAILURE, "dataset %s is not under %s", dataset, parent_ds);
+
+        /* TODO Task 4: look up dataset's mountpoint property; mount(2) it */
 
         if (do_unmount) {
                 /* TODO Task 5 */
@@ -172,6 +246,7 @@ main(int argc, char *argv[])
         if (do_mount(dataset, "/tmp/zfs-mount-skeleton-stub", "zfs", 0, NULL) < 0)
                 err(EXIT_FAILURE, "mount failed");
 
+        free(parent_ds);
         free(data_path);
         return (EXIT_SUCCESS);
 }

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _GNU_SOURCE
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <unistd.h>
+
+#include "common.h"
+
+static struct capabilities_v3 caps;
+
+static void
+init_capabilities(void)
+{
+        CAP_INIT_V3(&caps);
+
+        if (capget(&caps.hdr, caps.data) < 0)
+                err(EXIT_FAILURE, "failed to get capabilities");
+
+        CAP_FOREACH(&caps, n) {
+                if (n == CAP_DAC_READ_SEARCH || n == CAP_DAC_OVERRIDE)
+                        continue;
+                CAP_CLR(&caps, permitted, n);
+                CAP_CLR(&caps, effective, n);
+                CAP_CLR(&caps, inheritable, n);
+        }
+        CAP_SET(&caps, permitted, CAP_SYS_ADMIN);
+
+        if (capset(&caps.hdr, caps.data) < 0)
+                err(EXIT_FAILURE, "failed to set capabilities");
+}
+
+static int
+do_mount(const char *source, const char *target, const char *fstype,
+         unsigned long flags, const void *data)
+{
+        int rv;
+
+        CAP_SET(&caps, effective, CAP_SYS_ADMIN);
+        if (capset(&caps.hdr, caps.data) < 0)
+                return (-1);
+
+        rv = mount(source, target, fstype, flags, data);
+
+        CAP_CLR(&caps, effective, CAP_SYS_ADMIN);
+        if (capset(&caps.hdr, caps.data) < 0)
+                return (-1);
+        return (rv);
+}
+
+static void NORETURN
+usage(const char *progname, int status)
+{
+        FILE *out = (status == EXIT_SUCCESS) ? stdout : stderr;
+        fprintf(out, "Usage: %s [--unmount] DATASET\n", progname);
+        fprintf(out, "\n");
+        fprintf(out, "  Mount a ZFS DATASET at its declared mountpoint property.\n");
+        fprintf(out, "  With --unmount, unmount the dataset's current mountpoint.\n");
+        fprintf(out, "\n");
+        fprintf(out, "  Refuses to operate on datasets outside the parent of\n");
+        fprintf(out, "  ENROOT_DATA_PATH (read from /etc/enroot/enroot.conf), or\n");
+        fprintf(out, "  whose mountpoint is not under ENROOT_DATA_PATH.\n");
+        exit(status);
+}
+
+int
+main(int argc, char *argv[])
+{
+        bool do_unmount = false;
+        const char *dataset = NULL;
+
+        if (argc == 2 && !strcmp(argv[1], "--help"))
+                usage(argv[0], EXIT_SUCCESS);
+
+        if (argc == 2) {
+                dataset = argv[1];
+        } else if (argc == 3 && !strcmp(argv[1], "--unmount")) {
+                do_unmount = true;
+                dataset = argv[2];
+        } else {
+                usage(argv[0], EXIT_FAILURE);
+        }
+
+        init_capabilities();
+
+        /* TODO Task 2-4: validate the dataset before doing privileged work */
+
+        if (do_unmount) {
+                /* TODO Task 5 */
+                errx(EXIT_FAILURE, "unmount not implemented yet");
+        }
+
+        if (do_mount(dataset, "/tmp/zfs-mount-skeleton-stub", "zfs", 0, NULL) < 0)
+                err(EXIT_FAILURE, "mount failed");
+
+        return (EXIT_SUCCESS);
+}

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -363,6 +363,21 @@ main(int argc, char *argv[])
         if (!path_under(mp, data_path))
                 errx(EXIT_FAILURE, "mountpoint %s is not under %s", mp, data_path);
 
+        /* If the dataset is already mounted, succeed silently iff at the
+         * expected mountpoint; error otherwise (defends against double-mounts
+         * and surprises if a sibling mount table got reshuffled). */
+        char *cur = find_current_mountpoint(dataset);
+        if (cur != NULL) {
+                if (strcmp(cur, mp) == 0) {
+                        free(cur);
+                        free(mp);
+                        free(parent_ds);
+                        free(data_path);
+                        return (EXIT_SUCCESS);
+                }
+                errx(EXIT_FAILURE, "dataset %s is already mounted at %s", dataset, cur);
+        }
+
         /* mkdir runs as the calling uid (DAC_OVERRIDE is in permitted but not
          * effective; we don't raise it). If the dir already exists this is a
          * no-op. If the calling user can't create it, that's the right

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -16,7 +16,6 @@
 
 #define _GNU_SOURCE
 #include <err.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -25,7 +24,66 @@
 
 #include "common.h"
 
+#ifndef SYSCONFDIR
+# define SYSCONFDIR "/usr/local/etc"
+#endif
+#define CONF_PATH SYSCONFDIR "/enroot/enroot.conf"
+
 static struct capabilities_v3 caps;
+
+/*
+ * Reads ENROOT_DATA_PATH from the system enroot.conf. Returns a malloc'd
+ * string the caller must free, or NULL if the key is absent. Errors out if
+ * the conf file itself can't be opened.
+ *
+ * Format mirrors the bash side's IFS=$' \t=' read: lines are `KEY VALUE`
+ * with whitespace or `=` as separator. Comments start with `#`.
+ */
+static char *
+read_data_path(void)
+{
+        FILE *f;
+        char *line = NULL;
+        size_t len = 0;
+        ssize_t n;
+        char *result = NULL;
+
+        f = fopen(CONF_PATH, "r");
+        if (f == NULL)
+                err(EXIT_FAILURE, "cannot read %s", CONF_PATH);
+
+        while ((n = getline(&line, &len, f)) != -1) {
+                char *p, *key;
+
+                if (n > 0 && line[n - 1] == '\n')
+                        line[n - 1] = '\0';
+
+                p = line;
+                while (*p == ' ' || *p == '\t')
+                        p++;
+                if (*p == '\0' || *p == '#')
+                        continue;
+
+                key = p;
+                while (*p && *p != ' ' && *p != '\t' && *p != '=')
+                        p++;
+                if (*p == '\0')
+                        continue;
+                *p++ = '\0';
+                while (*p == ' ' || *p == '\t' || *p == '=')
+                        p++;
+
+                if (!strcmp(key, "ENROOT_DATA_PATH")) {
+                        result = strdup(p);
+                        if (result == NULL)
+                                err(EXIT_FAILURE, "strdup");
+                        break;
+                }
+        }
+        free(line);
+        fclose(f);
+        return (result);
+}
 
 static void
 init_capabilities(void)
@@ -101,7 +159,10 @@ main(int argc, char *argv[])
 
         init_capabilities();
 
-        /* TODO Task 2-4: validate the dataset before doing privileged work */
+        char *data_path = read_data_path();
+        if (data_path == NULL)
+                errx(EXIT_FAILURE, "ENROOT_DATA_PATH is not set in %s", CONF_PATH);
+        /* TODO Task 3-4: validate the dataset is under data_path's parent dataset */
 
         if (do_unmount) {
                 /* TODO Task 5 */
@@ -111,5 +172,6 @@ main(int argc, char *argv[])
         if (do_mount(dataset, "/tmp/zfs-mount-skeleton-stub", "zfs", 0, NULL) < 0)
                 err(EXIT_FAILURE, "mount failed");
 
+        free(data_path);
         return (EXIT_SUCCESS);
 }

--- a/bin/enroot-zfs-mount.c
+++ b/bin/enroot-zfs-mount.c
@@ -84,15 +84,59 @@ resolve_parent_dataset(const char *data_path)
         return (best_src);
 }
 
-/* Returns true iff dataset is exactly parent or a child path under parent/. */
-static bool
-dataset_under(const char *dataset, const char *parent)
-{
-        size_t pl = strlen(parent);
 
-        if (strncmp(dataset, parent, pl) != 0)
+/*
+ * Returns the ZFS `mountpoint` property of `dataset` (malloc'd absolute path),
+ * or NULL on error / non-path values (e.g. "none", "legacy", "-"). Exec's
+ * `zfs get -H -o value mountpoint DATASET` via popen.
+ */
+static char *
+get_mountpoint(const char *dataset)
+{
+        char cmd[PATH_MAX + 64];
+        FILE *p;
+        char buf[PATH_MAX];
+        char *result = NULL;
+
+        /* dataset is single-quote-wrapped in the shell. ZFS dataset names
+         * cannot contain single quotes (per the ZFS naming rules — only
+         * alphanumerics, period, underscore, dash, colon, and slash), so
+         * shell-injection via the dataset arg is not possible here. The
+         * dataset has already been prefix-validated by path_under(). */
+        int n = snprintf(cmd, sizeof(cmd),
+                         "zfs get -H -o value mountpoint '%s' 2>/dev/null", dataset);
+        if (n < 0 || n >= (int)sizeof(cmd))
+                return (NULL);
+
+        p = popen(cmd, "r");
+        if (p == NULL)
+                return (NULL);
+
+        if (fgets(buf, sizeof(buf), p) != NULL) {
+                size_t l = strlen(buf);
+                if (l > 0 && buf[l - 1] == '\n')
+                        buf[l - 1] = '\0';
+                if (buf[0] == '/') {
+                        result = strdup(buf);
+                        if (result == NULL) {
+                                SAVE_ERRNO(pclose(p));
+                                err(EXIT_FAILURE, "strdup");
+                        }
+                }
+        }
+        pclose(p);
+        return (result);
+}
+
+/* Returns true iff path is exactly prefix or under prefix/. */
+static bool
+path_under(const char *path, const char *prefix)
+{
+        size_t pl = strlen(prefix);
+
+        if (strncmp(path, prefix, pl) != 0)
                 return (false);
-        return (dataset[pl] == '\0' || dataset[pl] == '/');
+        return (path[pl] == '\0' || path[pl] == '/');
 }
 
 static struct capabilities_v3 caps;
@@ -233,19 +277,31 @@ main(int argc, char *argv[])
         if (parent_ds == NULL)
                 errx(EXIT_FAILURE, "no ZFS dataset is mounted at or above %s", data_path);
 
-        if (!dataset_under(dataset, parent_ds))
+        if (!path_under(dataset, parent_ds))
                 errx(EXIT_FAILURE, "dataset %s is not under %s", dataset, parent_ds);
-
-        /* TODO Task 4: look up dataset's mountpoint property; mount(2) it */
 
         if (do_unmount) {
                 /* TODO Task 5 */
                 errx(EXIT_FAILURE, "unmount not implemented yet");
         }
 
-        if (do_mount(dataset, "/tmp/zfs-mount-skeleton-stub", "zfs", 0, NULL) < 0)
-                err(EXIT_FAILURE, "mount failed");
+        char *mp = get_mountpoint(dataset);
+        if (mp == NULL)
+                errx(EXIT_FAILURE, "could not get mountpoint of %s (is it set to a path?)", dataset);
+        if (!path_under(mp, data_path))
+                errx(EXIT_FAILURE, "mountpoint %s is not under %s", mp, data_path);
 
+        /* mkdir runs as the calling uid (DAC_OVERRIDE is in permitted but not
+         * effective; we don't raise it). If the dir already exists this is a
+         * no-op. If the calling user can't create it, that's the right
+         * outcome — they don't have access to the parent. */
+        if (mkdir(mp, 0755) < 0 && errno != EEXIST)
+                err(EXIT_FAILURE, "mkdir %s", mp);
+
+        if (do_mount(dataset, mp, "zfs", 0, NULL) < 0)
+                err(EXIT_FAILURE, "mount %s on %s", dataset, mp);
+
+        free(mp);
         free(parent_ds);
         free(data_path);
         return (EXIT_SUCCESS);

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -199,12 +199,22 @@ A site enabling the ZFS backend should:
 
    `zfs receive` from `.zfs` files and `zfs://` requires this delegation. Without it, the ZFS backend operates only on already-received templates.
 
-   **Linux mount(2) caveat:** ZFS delegation governs ZFS's *internal* logic, but on Linux the kernel `mount(2)` syscall still requires `CAP_SYS_ADMIN`. As a result, an unprivileged user invoking `enroot create` on the ZFS backend will see "filesystem successfully created, but it may only be mounted by root" warnings, and the dataset will not be auto-mounted. The two practical workarounds:
+   **Linux mount(2) bypass via `enroot-zfs-mount`:** ZFS delegation governs
+   ZFS's *internal* logic, but on Linux the kernel `mount(2)` syscall still
+   requires `CAP_SYS_ADMIN`. The `enroot+caps` package installs
+   `enroot-zfs-mount` with `cap_sys_admin+pe`; the helper validates that the
+   caller-supplied dataset is under the parent dataset of `ENROOT_DATA_PATH`
+   (read from `/etc/enroot/enroot.conf`, NOT from user-controlled config),
+   that its `mountpoint` property is under `ENROOT_DATA_PATH`, and that it
+   isn't already mounted, before performing `mount(2)` / `umount2(2)`. With
+   `+caps` installed, all unprivileged ZFS-backed flows (`enroot create`,
+   `enroot load`, `enroot start <image>`, `enroot remove`) work end-to-end —
+   including from inside `slurmstepd` post-privilege-drop, which is what
+   pyxis needs.
 
-   - **Privileged `create`, unprivileged everything else.** Run `enroot create` (and `enroot load`) as root or via sudo; `enroot start`, `exec`, and `remove` work unprivileged because they operate on already-mounted datasets or use mount-namespace tricks that don't need additional CAP_SYS_ADMIN.
-   - **`fs.namespace.unprivileged_userns_clone=1` + per-user mount namespace.** A wrapper that enters a user namespace before `enroot create` lets the ZFS auto-mount succeed without root, at the cost of complexity and a small overhead.
-
-   On hosts where the same operator runs `create` and `start`, the privileged-create approach is simpler and matches enroot's existing model where image conversion (`enroot import`/`enroot-aufs2ovlfs`) already requires elevated privileges.
+   Without `+caps`, unprivileged callers cannot mount ZFS datasets and must
+   run `enroot create` and friends as root (e.g., via sudo or a
+   privilege-elevated systemd unit). The `dir` backend is unaffected.
 
    **Linux user-namespace caveat:** `zfs list` cannot enumerate datasets from inside a Linux user namespace — even when their mount entries are visible — so any ZFS work must happen *before* `enroot-nsenter --user`. For ephemeral `enroot start <image>` (Plan E), the ephemeral clone is created in `runtime::start` outside the namespace; cleanup is handled by a small "zfs-eph-shim" subshell that mirrors the existing `runtime::_mount_rootfs_shim` pattern — forked into its own process group, parked with `SIGSTOP`, and triggered to `zfs destroy` via the kernel's orphaned-process-group `SIGHUP` rule when the container's exec chain exits. The original `exec enroot-nsenter ...` chain is preserved, so PID semantics, signal forwarding, and `enroot exec PID` all work identically to the `dir` backend.
 

--- a/pkg/deb/PACKAGE+caps.postinst
+++ b/pkg/deb/PACKAGE+caps.postinst
@@ -9,6 +9,7 @@ case "$1" in
     configure|abort-upgrade|abort-remove|abort-deconfigure)
         setcap cap_sys_admin+pe "$(command -v enroot-mksquashovlfs)"
         setcap cap_sys_admin,cap_mknod+pe "$(command -v enroot-aufs2ovlfs)"
+        setcap cap_sys_admin+pe "$(command -v enroot-zfs-mount)"
     ;;
 
     *)

--- a/pkg/deb/PACKAGE+caps.prerm
+++ b/pkg/deb/PACKAGE+caps.prerm
@@ -9,6 +9,7 @@ case "$1" in
     remove|upgrade|deconfigure)
         setcap cap_sys_admin-pe "$(command -v enroot-mksquashovlfs)"
         setcap cap_sys_admin,cap_mknod-pe "$(command -v enroot-aufs2ovlfs)"
+        setcap cap_sys_admin-pe "$(command -v enroot-zfs-mount)"
     ;;
 
     failed-upgrade)

--- a/pkg/deb/changelog
+++ b/pkg/deb/changelog
@@ -1,3 +1,12 @@
+#PACKAGE# (4.1.2.zfs.2-1) UNRELEASED; urgency=medium
+
+  * Add bin/enroot-zfs-mount cap_sys_admin helper (shipped with enroot+caps)
+    that validates and performs mount(2)/umount2(2) of ZFS datasets owned by
+    the calling user, so that unprivileged enroot create/load/start/remove
+    work on the ZFS backend (issue #9 — pyxis/Slurm integration).
+
+ -- #USERNAME# <#EMAIL#>  Wed, 29 Apr 2026 16:00:00 +0000
+
 #PACKAGE# (4.1.2.zfs.1-1) UNRELEASED; urgency=medium
 
   * Add optional ZFS storage backend (ENROOT_STORAGE_BACKEND=zfs).

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -114,6 +114,7 @@ zfs::sweep_templates() {
         fi
         common::log INFO "Evicting template ${ds##*/} (age ${age}s)"
         zfs destroy "${ds}@${zfs_pristine_snap}" 2> /dev/null || :
+        enroot-zfs-mount --unmount "${ds}" 2> /dev/null || :
         zfs destroy "${ds}" 2> /dev/null || :
         if [ -n "${pressure}" ]; then
             zfs::under_pressure || break
@@ -148,9 +149,25 @@ zfs::ensure_template() {
         return
     fi
 
+    # Ensure the templates parent exists. Use -u so Linux does not auto-mount it
+    # (which would require CAP_SYS_ADMIN); mount it explicitly via the helper.
+    local -r templates_ds="${store}/${zfs_template_subdir}"
+    zfs create -u "${templates_ds}" 2> /dev/null || :
+    enroot-zfs-mount "${templates_ds}" 2> /dev/null || :
+
     # Try to create the .tmp dataset atomically. Whoever wins is the extractor.
-    if zfs create -p "${tmp}" 2> /dev/null; then
-        # We won — extract.
+    # -u: skip auto-mount (Linux requires CAP_SYS_ADMIN for mount(2)); we call
+    # enroot-zfs-mount explicitly below. No -p needed — parent was ensured above.
+    if zfs create -u "${tmp}" 2> /dev/null; then
+        # We won — mount it via the cap-elevated helper so unprivileged callers
+        # can write into it. Linux mount(2) needs CAP_SYS_ADMIN regardless of
+        # 'zfs allow' delegation; enroot-zfs-mount (in the +caps package)
+        # carries cap_sys_admin and validates the dataset is under
+        # ENROOT_DATA_PATH before mounting.
+        if ! enroot-zfs-mount "${tmp}" 2> /dev/null; then
+            zfs destroy "${tmp}" 2> /dev/null || :
+            common::err "failed to mount template; install enroot+caps to enable unprivileged mount"
+        fi
         mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
         common::log INFO "Extracting squashfs filesystem into ZFS template..." NL
         [ $(ulimit -n) -gt $((2**26)) ] && ulimit -n $((2**26))
@@ -164,7 +181,9 @@ zfs::ensure_template() {
                    common::err "Extraction failed even after evicting warm templates"; }
         fi
         common::fixperms "${mountpoint}"
+        enroot-zfs-mount --unmount "${tmp}" 2> /dev/null || :
         zfs rename "${tmp}" "${template}"
+        enroot-zfs-mount "${template}" 2> /dev/null || :
         zfs snapshot "${snap}"
         zfs set readonly=on "${template}"
         zfs::touch_template "${template}"
@@ -199,7 +218,11 @@ zfs::clone_container() {
         zfs destroy -r "${target}"
     fi
 
-    zfs clone "${template}@${zfs_pristine_snap}" "${target}"
+    zfs clone -u "${template}@${zfs_pristine_snap}" "${target}"
+    if ! enroot-zfs-mount "${target}" 2> /dev/null; then
+        zfs destroy "${target}" 2> /dev/null || :
+        common::err "failed to mount cloned container ${name}"
+    fi
 }
 
 # Destroys a user container. The clone's origin template is left in place;
@@ -215,6 +238,7 @@ zfs::destroy_container() {
     if ! zfs list -H "${target}" > /dev/null 2>&1; then
         common::err "No such container: ${name}"
     fi
+    enroot-zfs-mount --unmount "${target}" 2> /dev/null || :
     zfs destroy "${target}"
 }
 
@@ -232,9 +256,14 @@ zfs::ephemeral_clone() {
     template=$(zfs::ensure_template "${image}" "${sha}")
 
     clone="${store}/${zfs_ephemeral_subdir}/${$}-${sha:0:12}"
-    zfs create -p "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
-    zfs clone "${template}@${zfs_pristine_snap}" "${clone}"
+    zfs create -u "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
+    enroot-zfs-mount "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
+    zfs clone -u "${template}@${zfs_pristine_snap}" "${clone}"
     zfs set readonly=off "${clone}"
+    if ! enroot-zfs-mount "${clone}" 2> /dev/null; then
+        zfs destroy "${clone}" 2> /dev/null || :
+        common::err "failed to mount ephemeral clone"
+    fi
 
     mountpoint=$(zfs get -H -o value mountpoint "${clone}")
     printf "%s\t%s" "${clone}" "${mountpoint}"
@@ -244,6 +273,7 @@ zfs::ephemeral_clone() {
 zfs::ephemeral_destroy() {
     local -r clone="$1"
     [ -z "${clone}" ] && return
+    enroot-zfs-mount --unmount "${clone}" 2> /dev/null || :
     zfs destroy "${clone}" 2> /dev/null || :
 }
 
@@ -346,7 +376,8 @@ zfs::import_uri() {
             local -r store=$(zfs::store_dataset)
             local -r tmp_ds="${store}/${zfs_template_subdir}/import-$$.tmp"
             local mountpoint
-            zfs create -p "${store}/${zfs_template_subdir}" 2> /dev/null || :
+            zfs create -u "${store}/${zfs_template_subdir}" 2> /dev/null || :
+            enroot-zfs-mount "${store}/${zfs_template_subdir}" 2> /dev/null || :
             common::log INFO "Pulling ${remote_name} from ${host} (sqsh)" NL
             if ! ssh "${host}" enroot export --zfs-send "${remote_name}" \
                   | zfs receive -F "${tmp_ds}"; then
@@ -466,14 +497,21 @@ zfs::ensure_template_from_stream() {
     fi
 
     # Ensure the templates parent exists before receive (zfs receive does not
-    # auto-create parents).
-    zfs create -p "${store}/${zfs_template_subdir}" 2> /dev/null || :
+    # auto-create parents). Use -u to skip auto-mount; mount explicitly.
+    zfs create -u "${store}/${zfs_template_subdir}" 2> /dev/null || :
+    enroot-zfs-mount "${store}/${zfs_template_subdir}" 2> /dev/null || :
 
-    if zfs receive -F "${tmp}" < "${stream}" 2> /dev/null; then
+    if zfs receive -u -F "${tmp}" < "${stream}" 2> /dev/null; then
+        if ! enroot-zfs-mount "${tmp}" 2> /dev/null; then
+            zfs destroy -r "${tmp}" 2> /dev/null || :
+            common::err "failed to mount received template"
+        fi
         # The received dataset brings its own snapshot. Rename the dataset to
         # the final template name; if the recv'd snapshot wasn't already named
         # @pristine, alias it.
+        enroot-zfs-mount --unmount "${tmp}" 2> /dev/null || :
         zfs rename "${tmp}" "${template}"
+        enroot-zfs-mount "${template}" 2> /dev/null || :
         if ! zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
             local recvd_snap
             recvd_snap=$(zfs list -H -t snapshot -o name -r -d 1 "${template}" | head -1)
@@ -550,10 +588,18 @@ zfs::docker_install_from_layers() {
 
     zfs::sweep_templates
 
+    # Ensure the templates parent exists without auto-mounting it.
+    zfs create -u "${store}/${zfs_template_subdir}" 2> /dev/null || :
+    enroot-zfs-mount "${store}/${zfs_template_subdir}" 2> /dev/null || :
+
     if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
         common::log INFO "Reusing cached template ${cache_key:0:12}"
         zfs::touch_template "${template}"
-    elif zfs create -p "${tmp}" 2> /dev/null; then
+    elif zfs create -u "${tmp}" 2> /dev/null; then
+        if ! enroot-zfs-mount "${tmp}" 2> /dev/null; then
+            zfs destroy "${tmp}" 2> /dev/null || :
+            common::err "failed to mount docker template"
+        fi
         mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
         mkdir -p rootfs
         local merge_cmd
@@ -566,7 +612,9 @@ zfs::docker_install_from_layers() {
               || { zfs destroy -r "${tmp}" 2> /dev/null || :; \
                    common::err "Failed to merge Docker layers into ZFS template even after evicting warm templates"; }
         fi
+        enroot-zfs-mount --unmount "${tmp}" 2> /dev/null || :
         zfs rename "${tmp}" "${template}"
+        enroot-zfs-mount "${template}" 2> /dev/null || :
         zfs snapshot "${snap}"
         zfs set readonly=on "${template}"
         zfs::touch_template "${template}"


### PR DESCRIPTION
Closes #9 (pyxis/Slurm post-privilege-drop `enroot create` timeout on the ZFS backend).

Adds `bin/enroot-zfs-mount`, a small `cap_sys_admin`-elevated C helper that lets unprivileged callers mount ZFS datasets enroot creates. Wired into all five `mount(2)`-needing paths in `src/storage_zfs.sh` and the four `umount(2)`-needing destroy paths. Shipped via the `enroot+caps` package (no behavior change for anyone who doesn't install `+caps`).

## What changed

- **`bin/enroot-zfs-mount.c`** (~270 lines, static-pie/musl) — validates `[--unmount] DATASET`, then mounts/unmounts via `mount(2)`/`umount2(2)`. Validation chain (in order):
  - Reads authoritative `ENROOT_DATA_PATH` from `/etc/enroot/enroot.conf` (NOT user's `~/.config/enroot/enroot.conf`).
  - Resolves the parent ZFS dataset by walking `/proc/self/mounts` for the longest-prefix `zfs` mount covering that path.
  - Refuses datasets that aren't under the parent (e.g., `tank/admin/secrets`).
  - Reads the dataset's `mountpoint` ZFS property; refuses if it's not under `ENROOT_DATA_PATH` (defends against a self-owned dataset with a hostile mountpoint like `/usr/local/bin`).
  - On mount: idempotent if already mounted at the expected path; errors if mounted at an unexpected path.
  - On unmount: validates current mountpoint is under `ENROOT_DATA_PATH` before `umount2`; idempotent if not currently mounted.
  - Cap hygiene: `CAP_SYS_ADMIN` held in `permitted` only by default; raised in `effective` only around `mount(2)`/`umount2(2)` syscalls (mirrors the `do_setxattr()` pattern in `enroot-aufs2ovlfs.c`).
- **`src/storage_zfs.sh`** — five create/clone/recv sites switched to the `-u` (skip-auto-mount) variant + `enroot-zfs-mount` invocation; three destroy sites get `enroot-zfs-mount --unmount` before `zfs destroy`. Template-creation paths bracket the `.tmp → final` rename with unmount/remount.
- **`Makefile`** — `bin/enroot-zfs-mount` added to `UTILS`; per-target `-DSYSCONFDIR` plumbing; `setcap` target gains the helper.
- **`pkg/deb/PACKAGE+caps.{postinst,prerm}`** — grants/drops `cap_sys_admin+pe` on the helper alongside the existing two.
- **`Makefile`** — `VERSION` bumped to `4.1.2.zfs.2`.
- **`pkg/deb/changelog`** — new entry describing the change.
- **`doc/zfs.md`** — replaces the "Linux mount(2) caveat" section with a description of the new bypass.

## Implementation notes worth flagging

- **`zfs create -p -u` is leaky.** The `-u` flag (skip auto-mount) only applies to the leaf dataset; intermediate parents created by `-p` still auto-mount. The script now pre-creates each parent dataset explicitly via `zfs create -u <parent>` + `enroot-zfs-mount <parent>` before creating the leaf.
- **`zfs set readonly=on` on a mounted dataset wants to remount.** ZFS prints "property may be set but unable to remount filesystem" when the unprivileged caller can't remount-readonly. The property does land; the live mount stays read-write until next mount. Acceptable since templates aren't user-writable in practice (clones diverge into their own datasets).

## Test Plan

Verified manually on a loopback ZFS pool on Linux 6.12.75 (aarch64), zfs-2.4.1:

- [x] **Issue #9 reproducer:** `enroot create -f -n test /tmp/test.sqsh` as the unprivileged user completes in seconds (vs. the 10-minute timeout on `4.1.2.zfs.1`).
- [x] **Clone-on-create:** second `enroot create` from the same image completes in 0.14s.
- [x] **`enroot remove`:** unprivileged remove cleanly unmounts and destroys the user's clone.
- [x] **Helper input validation:**
  - Out-of-prefix dataset: `dataset tank/admin/secrets is not under tank/enroot/data`.
  - Hostile mountpoint property (`mountpoint=/usr/local/bin`): `mountpoint /usr/local/bin is not under /var/lib/enroot`.
  - Idempotent re-mount at expected path: exit 0, no double-mount.
  - Idempotent unmount on never-mounted: exit 0.
- [x] Build clean under strict CFLAGS (`-Wall -Wextra -Wcast-align -Wconversion -Wsign-conversion`).

## Trust posture

The helper has cap_sys_admin; that's a real trust expansion vs. installing the main package alone. The four checks above (system-config-only, prefix, mountpoint, already-mounted) bound that trust to the operations enroot itself does. A maliciously-crafted invocation cannot mount a dataset outside the enroot store, cannot mount a dataset at a hostile path, and cannot double-mount.

## Out of scope

- amd64 / x86_64 deb builds. Same constraint as `4.1.2.zfs.1` — needs a separate build host or the `pkg/release/docker-release-build.sh` flow.
- Doc-installation. Per earlier discussion, upstream doesn't ship docs in the deb; this PR doesn't either.