### PR TITLE
OpenZFS 2.2.x compat: zfs clone -u → -o canmount=noauto (closes #11)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIBDIR     = $(DESTDIR)$(libdir)/enroot
 SYSCONFDIR = $(DESTDIR)$(sysconfdir)/enroot
 DATADIR    = $(DESTDIR)$(datadir)/enroot
 
-VERSION       := 4.1.2.zfs.2
+VERSION       := 4.1.2.zfs.3
 PACKAGE       ?= enroot
 ARCH          ?= $(shell uname -m)
 DEBUG         ?=

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -193,11 +193,11 @@ A site enabling the ZFS backend should:
 3. **Delegate ZFS permissions** to unprivileged users so they can create, clone, and destroy datasets in their own namespace, and receive into the templates cache:
 
    ```sh
-   zfs allow user create,mount,clone,destroy,snapshot,rename tank/enroot
+   zfs allow user create,mount,clone,destroy,snapshot,rename,canmount,userprop tank/enroot
    zfs allow user receive tank/enroot/templates
    ```
 
-   `zfs receive` from `.zfs` files and `zfs://` requires this delegation. Without it, the ZFS backend operates only on already-received templates.
+   `zfs receive` from `.zfs` files and `zfs://` requires this delegation. Without it, the ZFS backend operates only on already-received templates. The `canmount` permission is needed for `zfs clone -o canmount=noauto` (the portable equivalent of `zfs clone -u`, which is OpenZFS 2.3+ only). The `userprop` permission is needed for `enroot:last_used` (the warm/cold lifecycle's per-template timestamp); without it, sweep behavior degrades but `create` / `remove` still work.
 
    **Linux mount(2) bypass via `enroot-zfs-mount`:** ZFS delegation governs
    ZFS's *internal* logic, but on Linux the kernel `mount(2)` syscall still

--- a/pkg/deb/changelog
+++ b/pkg/deb/changelog
@@ -1,3 +1,14 @@
+#PACKAGE# (4.1.2.zfs.3-1) UNRELEASED; urgency=medium
+
+  * Replace `zfs clone -u` (added in OpenZFS 2.3) with `zfs clone -o
+    canmount=noauto` (works in 2.0+) so the ZFS backend functions on Ubuntu
+    24.04 LTS and other distros pinned to OpenZFS 2.2.x userspace.
+    Recommended `zfs allow` list in doc/zfs.md gains `userprop` so the
+    template warm/cold lifecycle's `enroot:last_used` set succeeds for
+    unprivileged callers (issue #11).
+
+ -- #USERNAME# <#EMAIL#>  Wed, 29 Apr 2026 18:00:00 +0000
+
 #PACKAGE# (4.1.2.zfs.2-1) UNRELEASED; urgency=medium
 
   * Add bin/enroot-zfs-mount cap_sys_admin helper (shipped with enroot+caps)

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -218,7 +218,11 @@ zfs::clone_container() {
         zfs destroy -r "${target}"
     fi
 
-    zfs clone -u "${template}@${zfs_pristine_snap}" "${target}"
+    # canmount=noauto skips the auto-mount on create (works on OpenZFS 2.0+).
+    # `zfs clone -u` would do the same but is only in 2.3+; `-o canmount=noauto`
+    # is the portable equivalent. The helper's mount(2) call below is unaffected
+    # by canmount (it bypasses ZFS's own mount machinery).
+    zfs clone -o canmount=noauto "${template}@${zfs_pristine_snap}" "${target}"
     if ! enroot-zfs-mount "${target}" 2> /dev/null; then
         zfs destroy "${target}" 2> /dev/null || :
         common::err "failed to mount cloned container ${name}"
@@ -258,7 +262,9 @@ zfs::ephemeral_clone() {
     clone="${store}/${zfs_ephemeral_subdir}/${$}-${sha:0:12}"
     zfs create -u "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
     enroot-zfs-mount "${store}/${zfs_ephemeral_subdir}" 2> /dev/null || :
-    zfs clone -u "${template}@${zfs_pristine_snap}" "${clone}"
+    # canmount=noauto skips the auto-mount on clone (portable across OpenZFS
+    # 2.0+; `zfs clone -u` would do the same but is only in 2.3+).
+    zfs clone -o canmount=noauto "${template}@${zfs_pristine_snap}" "${clone}"
     zfs set readonly=off "${clone}"
     if ! enroot-zfs-mount "${clone}" 2> /dev/null; then
         zfs destroy "${clone}" 2> /dev/null || :


### PR DESCRIPTION
Closes #11.

`zenroot 4.1.2.zfs.2` started using `zfs clone -u` to skip auto-mount before the helper takes over. `-u` was added to `zfs clone` in **OpenZFS 2.3**. Ubuntu 24.04 LTS noble caps `zfsutils-linux` at **2.2.2-0ubuntu9.4** with no apt upgrade path; on those hosts pyxis-driven container start fails with:

```
[ERROR] invalid option 'u'
        usage: clone [-p] [-o property=value] ... <snapshot> <filesystem|volume>
```

This PR swaps `zfs clone -u` for `zfs clone -o canmount=noauto`, the portable equivalent. `canmount=noauto` instructs ZFS not to auto-mount the new dataset; the helper's explicit `mount(2)` syscall is unaffected (it bypasses ZFS's own mount machinery). Works on every OpenZFS userspace ≥ 2.0, including Ubuntu 24.04, RHEL 9, Debian 12.

## What changed

- **`src/storage_zfs.sh`** — two `zfs clone -u` call sites (`zfs::clone_container`, `zfs::ephemeral_clone`) replaced with `zfs clone -o canmount=noauto`. `zfs create -u` and `zfs receive -u` are unchanged — those flags are 2.0+.
- **`doc/zfs.md`** — recommended `zfs allow` recipe gains `canmount` (needed to set the property at clone time on the new path) and `userprop` (needed for the Plan B `enroot:last_used` timestamp; was a latent gap in the prior recipe surfaced in issue #11's traceback as `cannot set property ... permission denied`).
- **`Makefile`** — VERSION bumped to `4.1.2.zfs.3`.
- **`pkg/deb/changelog`** — new entry.

## Test Plan

Verified on the dev host (OpenZFS 2.4):

- [x] `enroot create` as unprivileged user with the new `canmount=noauto` clone path succeeds; rootfs populated.
- [x] Second create completes in ~0.18s (clone-on-create still fast).
- [x] `enroot remove` cleanly unmounts and destroys.
- [x] Initial test on a host with **only the old `zfs allow` list** correctly errors `cannot create ...: permission denied` — the documented requirement to add `canmount` to the allow list is real and the doc fix is necessary.

Affected users on Ubuntu 24.04 / Debian 12 / RHEL 9 should:

1. Apt-install the new `enroot_4.1.2.zfs.3-1_arm64.deb` (and `enroot+caps`).
2. `zfs allow user canmount,userprop tank/enroot` (in addition to whatever they already had).

## Out of scope

- amd64 / x86_64 deb builds (same constraint as `zfs.1` and `zfs.2` — needs a separate build host or the docker-release flow).
- Auto-detect of OpenZFS userspace version with a graceful fallback. Single portable code path is simpler and equivalent in cost.