### PR TITLE
ZFS: pointer-format cache for dockerd:// and podman:// imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LIBDIR     = $(DESTDIR)$(libdir)/enroot
 SYSCONFDIR = $(DESTDIR)$(sysconfdir)/enroot
 DATADIR    = $(DESTDIR)$(datadir)/enroot
 
-VERSION       := 4.1.2.zfs.4
+VERSION       := 4.1.2.zfs.5
 PACKAGE       ?= enroot
 ARCH          ?= $(shell uname -m)
 DEBUG         ?=

--- a/doc/zfs.md
+++ b/doc/zfs.md
@@ -87,6 +87,12 @@ imported=2026-04-29T18:23:11Z
 Pyxis treats the file as opaque (writes to a per-uid runtime dir, deletes it
 after `enroot create`), so the format change is invisible to pyxis.
 
+### Daemon URIs (`dockerd://`, `podman://`)
+
+`enroot import dockerd://<image>` and `enroot import podman://<image>` participate in the same pointer cache. The cache key is the daemon-reported image ID (`${engine} inspect --format='{{.Id}}'`), which matches the `image-config-sha256` of a `docker://`-pulled equivalent for registry-pulled images — so a daemon import of `ubuntu:24.04` shares the cache with a registry import of the same reference for free.
+
+Daemon-local images don't have a registry manifest digest, so the pointer file's `manifest-digest=` line is omitted. The `enroot:manifest-digest` user property is also unset on the corresponding template. All other fields (`enroot:uri`, `enroot:arch`, `enroot:imported`) are populated normally; the inspection one-liner above shows daemon-sourced templates with `enroot:uri=dockerd://...`.
+
 ### Opting out
 
 Set `ENROOT_ZFS_IMPORT_FORMAT=squashfs` in the environment or the config

--- a/docs/superpowers/plans/2026-05-01-zfs-daemon-pointer.md
+++ b/docs/superpowers/plans/2026-05-01-zfs-daemon-pointer.md
@@ -1,0 +1,726 @@
+# ZFS pointer-format for `dockerd://` / `podman://` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend the zfs.4 pointer cache so `enroot import dockerd://<image>` and `enroot import podman://<image>` get the same cache-hit behavior as `docker://`. Cache key is the daemon-reported image ID. Pointer format gains an optional (omittable) `manifest-digest` field.
+
+**Architecture:** Two new install / import primitives in `src/storage_zfs.sh` (`_install_template_from_dir`, `import_daemon_pointer`, `_extract_and_install_from_daemon`), refactor of `create_from_pointer`'s eviction-recovery to dispatch on URI scheme, a relaxed pointer URI regex, an optional `manifest-digest` schema, and a parallel branch in `runtime::import`'s dispatcher.
+
+**Tech Stack:** Bash, OpenZFS, the existing `enroot-zfs-mount` helper, the daemon side already used by `docker::daemon::import`.
+
+**Spec:** [docs/superpowers/specs/2026-05-01-zfs-daemon-pointer-design.md](../specs/2026-05-01-zfs-daemon-pointer-design.md).
+
+**Branch:** `feature/zfs-daemon-pointer` (already created, spec committed there).
+
+---
+
+## Task 1: Relax pointer schema (optional `manifest-digest`, widened URI regex)
+
+**Why:** Daemon-local images don't have a registry manifest digest, and the URI regex needs to accept `dockerd://` and `podman://`.
+
+**Files:** `src/storage_zfs.sh` — `zfs::write_pointer`, `zfs::read_pointer`, `zfs::set_template_metadata`.
+
+- [ ] **Step 1: Relax `write_pointer` — accept empty `manifest_digest`, omit the line when empty**
+
+Find in `zfs::write_pointer` (around line 195-215):
+
+```bash
+    [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+      || common::err "zfs::write_pointer: invalid manifest-digest: ${manifest_digest}"
+```
+
+Replace with:
+
+```bash
+    if [ -n "${manifest_digest}" ]; then
+        [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+          || common::err "zfs::write_pointer: invalid manifest-digest: ${manifest_digest}"
+    fi
+```
+
+Then find the line that emits the manifest-digest field:
+
+```bash
+        printf "manifest-digest=%s\n" "${manifest_digest}"
+```
+
+Wrap in a conditional:
+
+```bash
+        [ -n "${manifest_digest}" ] && printf "manifest-digest=%s\n" "${manifest_digest}"
+```
+
+- [ ] **Step 2: Relax URI regex in `write_pointer`**
+
+Find:
+
+```bash
+    [[ "${uri}" =~ ^docker://[A-Za-z0-9._:/@+-]+$ ]] \
+      || common::err "zfs::write_pointer: invalid uri: ${uri}"
+```
+
+Replace with:
+
+```bash
+    [[ "${uri}" =~ ^(docker|dockerd|podman)://[A-Za-z0-9._:/@+-]+$ ]] \
+      || common::err "zfs::write_pointer: invalid uri: ${uri}"
+```
+
+- [ ] **Step 3: Same relaxation in `read_pointer`**
+
+Find the validation block in `zfs::read_pointer`:
+
+```bash
+    [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+      || common::err "Pointer ${path} missing/invalid manifest-digest"
+```
+
+Replace with:
+
+```bash
+    if [ -n "${manifest_digest}" ]; then
+        [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+          || common::err "Pointer ${path} invalid manifest-digest"
+    fi
+```
+
+And the URI regex:
+
+```bash
+    [[ "${uri}" =~ ^docker://[A-Za-z0-9._:/@+-]+$ ]] \
+      || common::err "Pointer ${path} missing/invalid uri"
+```
+
+→
+
+```bash
+    [[ "${uri}" =~ ^(docker|dockerd|podman)://[A-Za-z0-9._:/@+-]+$ ]] \
+      || common::err "Pointer ${path} missing/invalid uri"
+```
+
+- [ ] **Step 4: `set_template_metadata` skips empty manifest-digest**
+
+Find:
+
+```bash
+zfs::set_template_metadata() {
+    local -r template="$1" uri="$2" manifest_digest="$3" arch="$4"
+    zfs set "enroot:uri=${uri}" "${template}" 2> /dev/null || :
+    zfs set "enroot:manifest-digest=${manifest_digest}" "${template}" 2> /dev/null || :
+    zfs set "enroot:arch=${arch}" "${template}" 2> /dev/null || :
+}
+```
+
+Replace the manifest-digest set with a conditional:
+
+```bash
+zfs::set_template_metadata() {
+    local -r template="$1" uri="$2" manifest_digest="$3" arch="$4"
+    zfs set "enroot:uri=${uri}" "${template}" 2> /dev/null || :
+    if [ -n "${manifest_digest}" ]; then
+        zfs set "enroot:manifest-digest=${manifest_digest}" "${template}" 2> /dev/null || :
+    fi
+    zfs set "enroot:arch=${arch}" "${template}" 2> /dev/null || :
+}
+```
+
+- [ ] **Step 5: Syntax-check + smoke**
+
+```bash
+bash -n src/storage_zfs.sh
+```
+
+Quick round-trip test that v4 pointers (with manifest-digest) and new pointers (without) both work:
+
+```bash
+bash -c "set -euo pipefail
+export ENROOT_LIBRARY_PATH=src
+source src/common.sh
+source src/storage_zfs.sh
+out=\$(mktemp)
+echo '=== with manifest-digest (v4 form) ==='
+zfs::write_pointer \"\${out}\" 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789' 'sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789' arm64 'docker://x/y:z'
+zfs::is_pointer \"\${out}\" && echo IS_POINTER
+zfs::read_pointer \"\${out}\"
+echo '=== without manifest-digest (new form) ==='
+zfs::write_pointer \"\${out}\" 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789' '' arm64 'dockerd://ubuntu:24.04'
+zfs::is_pointer \"\${out}\" && echo IS_POINTER
+cat \"\${out}\"
+zfs::read_pointer \"\${out}\"
+rm -f \"\${out}\"
+"
+```
+
+Expected: round-trip OK both forms; the without form has no `manifest-digest=` line in the file; both pass `is_pointer`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/storage_zfs.sh
+git commit -s -m "storage_zfs: relax pointer schema for daemon URIs
+
+Manifest-digest becomes optional in the pointer format (write_pointer
+omits the line when empty; read_pointer tolerates absence). The URI
+regex widens to ^(docker|dockerd|podman)://… so the cache can carry
+daemon-local image references that don't have a registry manifest digest.
+
+v1 magic line is unchanged; existing v4 pointers (always with
+manifest-digest) still parse correctly under the relaxed reader.
+
+set_template_metadata skips the enroot:manifest-digest property when
+the value is empty so daemon templates don't carry a confusing empty
+property."
+```
+
+---
+
+## Task 2: Add `zfs::_install_template_from_dir`
+
+**Why:** Daemon imports give us a flat rootfs (no overlayfs layers); we need a template-install primitive that fills the `.tmp` dataset from a single source directory.
+
+**Files:** `src/storage_zfs.sh` — append after the existing `zfs::_install_template_from_layers` (around line 800-870 area).
+
+- [ ] **Step 1: Locate `zfs::_install_template_from_layers`**
+
+```bash
+grep -n "^zfs::_install_template_from_layers\|^zfs::docker_install_from_layers" src/storage_zfs.sh
+```
+
+- [ ] **Step 2: Append the new helper directly after `zfs::docker_install_from_layers`**
+
+(Match the indentation, comment style, and atomicity tail of `_install_template_from_layers`. Tar-pipe is the simplest cross-FS copy that preserves perms/xattrs.)
+
+```bash
+
+# Materializes a flat rootfs directory tree into a ZFS template (cached
+# by cache_key). Counterpart of _install_template_from_layers for callers
+# that already have a single rootfs/ tree (e.g. docker::daemon::import,
+# which uses `${engine} export | tar -x` to produce a flat tree).
+#
+# Inputs:
+#   $1 cache_key   - sha256 of the image config (the daemon image ID)
+#   $2 source_dir  - directory containing the rootfs to install
+#   $3 unpriv      - "y" or "" — whether to enter a new user namespace
+#
+# Outputs: prints the template dataset path to stdout (no trailing newline).
+#
+# Atomicity: races on the same cache_key are resolved via a per-key .tmp
+# dataset lock; losers wait for @pristine. Same shape as
+# _install_template_from_layers.
+zfs::_install_template_from_dir() {
+    local -r cache_key="$1" source_dir="$2" unpriv="$3"
+    local store template tmp snap mountpoint i=0
+    store=$(zfs::store_dataset)
+    template="${store}/${zfs_template_subdir}/${cache_key}"
+    tmp="${template}.tmp"
+    snap="${template}@${zfs_pristine_snap}"
+
+    zfs::sweep_templates
+
+    zfs create -u "${store}/${zfs_template_subdir}" 2> /dev/null || :
+    enroot-zfs-mount "${store}/${zfs_template_subdir}" 2> /dev/null || :
+
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        common::log INFO "Reusing cached template ${cache_key:0:12}"
+        zfs::touch_template "${template}"
+    elif zfs create -u "${tmp}" 2> /dev/null; then
+        if ! enroot-zfs-mount "${tmp}" 2> /dev/null; then
+            zfs destroy "${tmp}" 2> /dev/null || :
+            common::err "failed to mount daemon template"
+        fi
+        mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
+        local copy_cmd
+        copy_cmd="tar --numeric-owner -C '${source_dir}/' --mode=u-s,g-s -cpf - . | tar --numeric-owner -C '${mountpoint}/' -xpf -"
+        if ! enroot-nsenter ${unpriv:+--user} --mount --remap-root bash -c "${copy_cmd}"; then
+            common::log WARN "Daemon template copy failed; evicting all warm templates and retrying"
+            ENROOT_TEMPLATE_WARM_SECONDS=0 zfs::sweep_templates
+            enroot-nsenter ${unpriv:+--user} --mount --remap-root bash -c "${copy_cmd}" \
+              || { zfs destroy -r "${tmp}" 2> /dev/null || :; \
+                   common::err "Failed to copy daemon rootfs into ZFS template even after evicting warm templates"; }
+        fi
+        enroot-zfs-mount --unmount "${tmp}" 2> /dev/null || :
+        zfs rename "${tmp}" "${template}"
+        enroot-zfs-mount "${template}" 2> /dev/null || :
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}" 2> /dev/null || :
+        zfs set "enroot:imported=$(date -u +%FT%TZ)" "${template}" 2> /dev/null || :
+        enroot-zfs-mount --unmount "${template}" 2> /dev/null || :
+        zfs::touch_template "${template}"
+    else
+        # Lost the race or stale .tmp — wait for @pristine.
+        while ! zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; do
+            sleep 1
+            ((i++ < 600)) || common::err "Timed out waiting for daemon template: ${template}"
+        done
+    fi
+
+    printf "%s" "${template}"
+}
+```
+
+- [ ] **Step 3: Syntax-check**
+
+```bash
+bash -n src/storage_zfs.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/storage_zfs.sh
+git commit -s -m "storage_zfs: add _install_template_from_dir
+
+Counterpart of _install_template_from_layers for callers that already
+have a flat rootfs (e.g. dockerd:// / podman:// imports, where
+\`\${engine} export | tar -x\` produces a single tree, not layered
+overlayfs directories). Same atomicity / race / snapshot / readonly /
+unmount-after-install / enroot:imported tail."
+```
+
+---
+
+## Task 3: Add `zfs::_extract_and_install_from_daemon`
+
+**Why:** Shared helper for the import path AND the eviction-recovery path. Modeled on `zfs::_pull_and_install_template`.
+
+**Files:** `src/storage_zfs.sh` — append near `zfs::_pull_and_install_template`.
+
+- [ ] **Step 1: Locate `zfs::_pull_and_install_template`**
+
+```bash
+grep -n "^zfs::_pull_and_install_template" src/storage_zfs.sh
+```
+
+- [ ] **Step 2: Append the daemon variant after it**
+
+```bash
+
+# Internal helper used by both the daemon-import flow and the
+# create_from_pointer recovery path for dockerd://podman:// URIs. Runs
+# \`\${engine} create + inspect + export | tar -x\`, populates the template
+# from the resulting flat rootfs, prints the resolved image-config-sha256
+# (the daemon image ID) so the caller can validate it. Does NOT write a
+# pointer file.
+#
+# Inputs:
+#   $1 uri    - dockerd://<image> or podman://<image>
+#   $2 arch   - already debarch-normalized (callers must convert with
+#               common::debarch first, or pass the value already stored
+#               in a pointer file).
+#
+# Subshell function for cwd / EXIT trap scoping (matches
+# _pull_and_install_template).
+zfs::_extract_and_install_from_daemon() (
+    local -r uri="$1" arch="$2"
+    local image= tmpdir= engine= cache_key= unpriv=
+    local image_id=
+
+    set -euo pipefail
+
+    case "${uri}" in
+        dockerd://*) engine="docker" ;;
+        podman://*)  engine="podman" ;;
+        *)           common::err "_extract_and_install_from_daemon: not a daemon URI: ${uri}" ;;
+    esac
+
+    common::checkcmd jq "${engine}" tar
+
+    local -r reg_image="[[:alnum:]/._:-]+"
+    if [[ "${uri}" =~ ^[[:alpha:]]+://(${reg_image})$ ]]; then
+        image="${BASH_REMATCH[1]}"
+    else
+        common::err "Invalid image reference: ${uri}"
+    fi
+
+    image_id=$("${engine}" inspect --format '{{.Id}}' "${image}") \
+      || common::err "${engine} inspect ${image} failed"
+    [[ "${image_id}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+      || common::err "${engine} returned unexpected image ID: ${image_id}"
+    cache_key="${image_id#sha256:}"
+
+    trap 'common::rmall "${tmpdir}" 2> /dev/null; "${engine}" rm -f -v "${tmpdir##*/}" > /dev/null 2>&1' EXIT
+    tmpdir=$(common::mktmpdir enroot)
+    common::chdir "${tmpdir}"
+
+    common::log INFO "Extracting image content from ${engine} daemon..." NL
+    "${engine}" create --name "${PWD##*/}" "${image}" >&2
+    mkdir rootfs
+    "${engine}" export "${PWD##*/}" \
+      | tar -C rootfs --warning=no-timestamp --anchored --exclude='dev/*' --exclude='.dockerenv' -px
+    common::fixperms rootfs
+    "${engine}" inspect "${image}" | common::jq '.[] | with_entries(.key|=ascii_downcase)' > config
+    docker::configure rootfs config "${arch}"
+
+    if [ "${EUID}" -ne 0 ]; then
+        unpriv=y
+    fi
+
+    zfs::_install_template_from_dir "${cache_key}" "${PWD}/rootfs" "${unpriv}" > /dev/null
+
+    printf "%s" "${cache_key}"
+)
+```
+
+- [ ] **Step 3: Syntax-check + dependency sanity**
+
+```bash
+bash -n src/storage_zfs.sh
+grep -n "_install_template_from_dir\|_extract_and_install_from_daemon" src/storage_zfs.sh
+```
+
+Both should appear (definition + nothing else yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/storage_zfs.sh
+git commit -s -m "storage_zfs: add _extract_and_install_from_daemon
+
+Daemon-side analog of zfs::_pull_and_install_template. Runs
+\`\${engine} create / inspect / export | tar -x\`, derives the cache key
+from the daemon's image ID, and populates the template via
+_install_template_from_dir. Subshell function with set -euo pipefail
+for cwd / EXIT scoping, matches the docker:// puller's pattern.
+
+No callers yet — wired in by Tasks 4 and 5."
+```
+
+---
+
+## Task 4: Add `zfs::import_daemon_pointer` (top-level entry)
+
+**Why:** Counterpart of `zfs::import_docker_pointer` for daemon URIs. Runs the daemon-extract + template-install + pointer-write pipeline.
+
+**Files:** `src/storage_zfs.sh` — append after `zfs::import_docker_pointer`.
+
+- [ ] **Step 1: Locate `zfs::import_docker_pointer`**
+
+```bash
+grep -n "^zfs::import_docker_pointer" src/storage_zfs.sh
+```
+
+- [ ] **Step 2: Append the daemon-side import**
+
+```bash
+
+# Import flow for dockerd://*  / podman://* URIs when the ZFS backend is
+# active and the pointer format is selected. Modeled on
+# import_docker_pointer but uses the daemon-extract path
+# (_extract_and_install_from_daemon). manifest-digest is empty —
+# daemon-local images don't have a registry manifest digest.
+#
+# Inputs:
+#   $1 uri          - dockerd://<image>  or  podman://<image>
+#   $2 output_path  - where to write the pointer (caller pre-validated)
+#   $3 arch         - raw uname -m form; normalized internally via
+#                     common::debarch.
+zfs::import_daemon_pointer() (
+    local -r uri="$1" output_path="$2"
+    local arch="$3"
+    local cache_key=
+
+    set -euo pipefail
+
+    if [ -n "${arch}" ]; then
+        arch=$(common::debarch "${arch}")
+    fi
+
+    cache_key=$(zfs::_extract_and_install_from_daemon "${uri}" "${arch}")
+
+    local store
+    store=$(zfs::store_dataset)
+    zfs::set_template_metadata "${store}/${zfs_template_subdir}/${cache_key}" \
+        "${uri}" "" "${arch}"
+
+    zfs::write_pointer "${output_path}" "${cache_key}" "" "${arch}" "${uri}"
+)
+```
+
+- [ ] **Step 3: Syntax-check**
+
+```bash
+bash -n src/storage_zfs.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/storage_zfs.sh
+git commit -s -m "storage_zfs: add zfs::import_daemon_pointer
+
+Top-level orchestrator for dockerd://podman:// pointer imports. Calls
+_extract_and_install_from_daemon to populate the template, stamps the
+docker provenance (uri + arch; no manifest-digest for daemon images),
+writes the pointer file. Empty manifest-digest is handled by the
+schema-relax in Task 1 — no \`manifest-digest=\` line is emitted, and
+the read_pointer side tolerates the absence."
+```
+
+---
+
+## Task 5: Refactor `zfs::create_from_pointer` recovery to dispatch on URI scheme
+
+**Why:** The existing recovery only knows how to re-pull `docker://` URIs. With daemon URIs in the mix, recovery branches.
+
+**Files:** `src/storage_zfs.sh` — `zfs::create_from_pointer`.
+
+- [ ] **Step 1: Locate the eviction-recovery block**
+
+```bash
+grep -n "fresh_config_sha=\|_pull_and_install_template" src/storage_zfs.sh
+```
+
+- [ ] **Step 2: Replace the single call with a scheme dispatch**
+
+Find:
+
+```bash
+    fresh_config_sha=$(zfs::_pull_and_install_template "${uri}" "${arch}")
+```
+
+Replace with:
+
+```bash
+    case "${uri}" in
+        docker://*)
+            fresh_config_sha=$(zfs::_pull_and_install_template "${uri}" "${arch}") ;;
+        dockerd://*|podman://*)
+            fresh_config_sha=$(zfs::_extract_and_install_from_daemon "${uri}" "${arch}") ;;
+        *)
+            common::err "Pointer ${pointer_path} has unsupported URI scheme: ${uri}" ;;
+    esac
+```
+
+- [ ] **Step 3: Syntax-check + verify dispatch**
+
+```bash
+bash -n src/storage_zfs.sh
+grep -n "_pull_and_install_template\|_extract_and_install_from_daemon\|fresh_config_sha=" src/storage_zfs.sh
+```
+
+Expected: each helper called exactly once from inside the case.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/storage_zfs.sh
+git commit -s -m "storage_zfs: dispatch eviction-recovery on URI scheme
+
+create_from_pointer now branches on docker:// vs dockerd://podman:// in
+its eviction-recovery path. Daemon URIs use the new
+_extract_and_install_from_daemon helper; docker:// URIs continue to use
+_pull_and_install_template. An unrecognized scheme errors with a clear
+message rather than silently picking the docker:// path."
+```
+
+---
+
+## Task 6: Wire `runtime::import` daemon-side branch
+
+**Why:** Make the dispatcher route `dockerd://*|podman://*` through `zfs::import_daemon_pointer` when the ZFS pointer format is active.
+
+**Files:** `src/runtime.sh` — `runtime::import`.
+
+- [ ] **Step 1: Read the current dispatcher**
+
+```bash
+grep -n "^runtime::import\|dockerd://\|podman://" src/runtime.sh
+```
+
+- [ ] **Step 2: Add the daemon branch**
+
+In `runtime::import`, find:
+
+```bash
+    dockerd://* | podman://*)
+        docker::daemon::import "${uri}" "${filename}" "${arch}" ;;
+```
+
+Replace with:
+
+```bash
+    dockerd://* | podman://*)
+        if zfs::pointer_format_active; then
+            # ZFS pointer-format daemon import: write a small magic-prefixed
+            # pointer file alongside populating the template cache.
+            # Filename defaulting mirrors docker::daemon::import — daemon URIs
+            # have a `<scheme>://<image-ref>` shape; default filename slugs
+            # the image ref into a .sqsh path.
+            if [ -z "${filename}" ]; then
+                local _image=
+                local -r _reg_image="[[:alnum:]/._:-]+"
+                if [[ "${uri}" =~ ^[[:alpha:]]+://(${_reg_image})$ ]]; then
+                    _image="${BASH_REMATCH[1]}"
+                else
+                    common::err "Invalid image reference: ${uri}"
+                fi
+                filename="${_image//[:\/]/+}.sqsh"
+            fi
+            filename=$(common::realpath "${filename}")
+            if [ -e "${filename}" ]; then
+                common::err "File already exists: ${filename}"
+            fi
+            zfs::import_daemon_pointer "${uri}" "${filename}" "${arch}"
+        else
+            docker::daemon::import "${uri}" "${filename}" "${arch}"
+        fi ;;
+```
+
+- [ ] **Step 3: Syntax-check**
+
+```bash
+bash -n src/runtime.sh
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/runtime.sh
+git commit -s -m "runtime: pointer-format dispatch for daemon URIs
+
+Adds the dockerd://podman:// branch parallel to the existing docker://
+branch in runtime::import. When ENROOT_STORAGE_BACKEND=zfs and
+ENROOT_ZFS_IMPORT_FORMAT is unset or 'pointer', daemon imports now call
+zfs::import_daemon_pointer (writes a pointer + populates the template
+cache, skips mksquashfs) instead of docker::daemon::import.
+
+Filename defaulting mirrors docker::daemon::import's '<image>.sqsh'
+slug. ENROOT_ZFS_IMPORT_FORMAT=squashfs preserves the legacy daemon
+import behavior."
+```
+
+---
+
+## Task 7: Doc note in `doc/zfs.md`
+
+**Why:** Operators reading the pointer-format section should know the cache covers daemon URIs too.
+
+**Files:** `doc/zfs.md` — the existing `## Pointer-format import (default on ZFS backend)` section.
+
+- [ ] **Step 1: Find the right place**
+
+```bash
+grep -n "^## Pointer-format import\|^### Opting out" doc/zfs.md
+```
+
+- [ ] **Step 2: Append a new subsection just before `### Opting out`**
+
+```markdown
+### Daemon URIs (`dockerd://`, `podman://`)
+
+`enroot import dockerd://<image>` and `enroot import podman://<image>` participate in the same pointer cache. The cache key is the daemon-reported image ID (`${engine} inspect --format='{{.Id}}'`), which matches the `image-config-sha256` of a `docker://`-pulled equivalent for registry-pulled images — so a daemon import of `ubuntu:24.04` shares the cache with a registry import of the same reference for free.
+
+Daemon-local images don't have a registry manifest digest, so the pointer file's `manifest-digest=` line is omitted. The `enroot:manifest-digest` user property is also unset on the corresponding template. All other fields (`enroot:uri`, `enroot:arch`, `enroot:imported`) are populated normally; the inspection one-liner above shows daemon-sourced templates with `enroot:uri=dockerd://...`.
+```
+
+- [ ] **Step 3: Verify code fences balance**
+
+```bash
+grep -c '^```' doc/zfs.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add doc/zfs.md
+git commit -s -m "doc: zfs.md note on daemon URI cache parity
+
+Documents that dockerd://podman:// imports use the same pointer cache
+as docker://, with the daemon image ID as the cache key. Notes the
+omitted manifest-digest field for daemon-local images."
+```
+
+---
+
+## Task 8: Smoke-test (manual, on a ZFS-backed node with docker or podman)
+
+The project has no automated tests. Verification is by hand.
+
+- [ ] **Step 1: Build .deb on dev box**
+
+```bash
+make clean
+rm -f ../enroot_*.orig.tar.* ../enroot-hardened_*.orig.tar.*
+CPPFLAGS="-DALLOW_SPECULATION -DINHERIT_FDS" make deb
+```
+
+- [ ] **Step 2: Install on a test node with docker daemon available**
+
+Per CLAUDE.md "Smoke-test cluster" section.
+
+- [ ] **Step 3: Pre-pull a known image into the daemon (if not already)**
+
+```bash
+sudo docker pull ubuntu:24.04
+```
+
+- [ ] **Step 4: Daemon pointer import**
+
+```bash
+rm -f /tmp/d.sqsh
+enroot import -o /tmp/d.sqsh dockerd://ubuntu:24.04
+ls -la /tmp/d.sqsh
+head -1 /tmp/d.sqsh
+cat /tmp/d.sqsh
+```
+
+Expected: file < 1 KiB; first line `enroot-zfs-image:v1`; body has `image-config-sha256=`, `arch=`, `uri=dockerd://ubuntu:24.04`, `imported=`; NO `manifest-digest=` line.
+
+- [ ] **Step 5: Cache-hit create**
+
+```bash
+enroot remove -f c1 2>/dev/null
+time enroot create -n c1 /tmp/d.sqsh
+enroot start c1 cat /etc/os-release | head -1
+enroot remove -f c1
+```
+
+Expected: subseconds; container starts.
+
+- [ ] **Step 6: Repeat-import idempotence**
+
+```bash
+sudo zfs list -H -d 1 -o name ${POOL}/.templates | wc -l
+rm -f /tmp/d.sqsh
+enroot import -o /tmp/d.sqsh dockerd://ubuntu:24.04
+sudo zfs list -H -d 1 -o name ${POOL}/.templates | wc -l
+```
+
+Expected: template count unchanged; "Reusing cached template" log.
+
+- [ ] **Step 7: Eviction recovery**
+
+```bash
+sudo zfs destroy -r ${POOL}/.templates/<image-id-sha>
+enroot remove -f c2 2>/dev/null
+enroot create -n c2 /tmp/d.sqsh
+enroot remove -f c2
+```
+
+Expected: re-extracts from the daemon and clones successfully.
+
+- [ ] **Step 8: docker:// path still works (no regression)**
+
+```bash
+rm -f /tmp/u.sqsh
+enroot import -o /tmp/u.sqsh docker://ubuntu:24.04
+head -1 /tmp/u.sqsh
+grep '^manifest-digest=' /tmp/u.sqsh   # should appear (registry-sourced)
+```
+
+- [ ] **Step 9: --format=squashfs opt-out for daemon URI**
+
+```bash
+rm -f /tmp/d-real.sqsh
+enroot import --format=squashfs -o /tmp/d-real.sqsh dockerd://ubuntu:24.04
+file /tmp/d-real.sqsh    # → Squashfs filesystem
+rm -f /tmp/d-real.sqsh
+```
+
+---
+
+## Self-Review Checklist
+
+1. **Spec coverage:** §3.1 (cache key) → Task 3. §3.2 (`_install_template_from_dir`) → Task 2. §3.3 (`import_daemon_pointer`) → Task 4. §3.4 (optional manifest-digest, URI regex relax) → Task 1. §3.5 (recovery dispatch) → Task 5. §3.6 (`runtime::import` wiring) → Task 6. §3.7 (doc) → Task 7.
+2. **Identifier consistency:** `zfs::_install_template_from_dir`, `zfs::_extract_and_install_from_daemon`, `zfs::import_daemon_pointer` named identically across plan, spec, and tasks. URI regex uses `^(docker|dockerd|podman)://` consistently in all three places (Task 1 steps 2, 3, and the conceptual schema).
+3. **No placeholders:** every code block is complete; no "TBD" / "TODO".

--- a/docs/superpowers/specs/2026-05-01-zfs-daemon-pointer-design.md
+++ b/docs/superpowers/specs/2026-05-01-zfs-daemon-pointer-design.md
@@ -1,0 +1,149 @@
+# ZFS pointer-format import for `dockerd://` and `podman://` URIs
+
+**Goal:** Extend the ZFS pointer-format cache (zfs.4) so `enroot import dockerd://<image>` and `enroot import podman://<image>` get the same cache-hit behavior as `enroot import docker://<ref>`. Repeat imports of the same daemon-local image populate the layer-keyed template cache once and clone subsequent times.
+
+**Status:** Approved-by-conversation 2026-05-01. Ready for implementation plan.
+
+## 1. Problem
+
+Post-zfs.4, `enroot import docker://<ref>` writes a 1 KiB pointer file and skips `mksquashfs` entirely; repeat imports hit the existing template cache via `image-config-sha256`. But `dockerd://*` and `podman://*` URIs still go through `docker::daemon::import`, which does:
+
+```
+${engine} create → ${engine} export | tar -x → rootfs/ → mksquashfs → .sqsh
+```
+
+There's no template population, no pointer, no cache. Repeat imports of the same daemon-local image redo the full export + squash every time. Pyxis-driven workflows that pull from a local podman registry (a common HPC pattern when registries are airgapped) get none of the zfs.4 win.
+
+## 2. Goal
+
+`enroot import dockerd://<image>` and `enroot import podman://<image>` (when ZFS backend is active and `ENROOT_ZFS_IMPORT_FORMAT=pointer`):
+
+1. Populate a ZFS template keyed by the daemon-reported image ID (sha256 of the image config).
+2. Write a pointer file at the requested output path. Pyxis treats it identically to a `docker://`-sourced pointer.
+3. On `enroot create`, the pointer-create path clones the template — `O(zfs clone)`.
+4. Eviction recovery re-runs `${engine} export` to repopulate the template, validating the freshly-resolved image ID matches the pointer's claim.
+
+`docker://` behavior is unchanged. `--format=squashfs` opt-out preserves the legacy `mksquashfs`-based path. `dir` backend is untouched.
+
+## 3. Approach
+
+### 3.1 Cache key
+
+`${engine} inspect --format='{{.Id}}' <image>` returns `sha256:<64-hex>`. Stripping the `sha256:` prefix gives a 64-hex string identical in shape and meaning to the `image-config-sha256` we already use for `docker://` imports. Use it as the cache key — same dataset naming convention, same template directory layout.
+
+For images that the daemon pulled from a registry, this matches the `image-config-sha256` we'd compute on a `docker://` import of the same reference. For locally-built images, it's still a stable content hash. Either way, it's the right cache key.
+
+### 3.2 New install path: flat directory → template
+
+`zfs::_install_template_from_layers` (zfs.4) merges N layered overlayfs layers into a `.tmp` dataset. For daemon imports we already have a flat rootfs from `${engine} export | tar -x`, so we don't need overlayfs at all.
+
+Add a new helper:
+
+```bash
+zfs::_install_template_from_dir <cache_key> <source_dir> <unpriv>
+```
+
+Same atomicity / race / snapshot / readonly tail as `_install_template_from_layers`, but the merge step is a single `tar -C "${source_dir}" -cpf - . | tar -C "${mountpoint}" -xpf -` (or a direct `mv`/rsync — whichever is simplest and matches existing project conventions). Returns the template path on stdout.
+
+### 3.3 New top-level: `zfs::import_daemon_pointer`
+
+```bash
+zfs::import_daemon_pointer <uri> <output_path> <arch>
+```
+
+Subshell function (matches `zfs::import_docker_pointer` style). Body:
+
+1. Parse `uri` → `engine` (`docker` / `podman`) and `image`.
+2. `common::checkcmd jq "${engine}" tar` (drop `mksquashfs` — we don't need it).
+3. `${engine} inspect "${image}"` → image ID, arch, config (uses existing `docker::configure`).
+4. Strip `sha256:` from image ID → `cache_key`.
+5. Verify arch matches the request (warn-only, same as `docker::configure`).
+6. Trap + tmpdir + `${engine} create` + `${engine} export | tar -x rootfs/` + `docker::configure rootfs config "${arch}"`.
+7. `zfs::_install_template_from_dir "${cache_key}" "${PWD}/rootfs" "${unpriv}"`.
+8. `zfs::set_template_metadata "${template}" "${uri}" "" "${arch}"` — note empty manifest-digest.
+9. `zfs::write_pointer "${output_path}" "${cache_key}" "" "${arch}" "${uri}"` — empty manifest-digest.
+
+### 3.4 Pointer schema: optional `manifest-digest`
+
+Daemon-local images don't have a registry manifest digest. The pointer format must accommodate that. Schema evolution (still v1 — backwards compatible with all zfs.4 pointers):
+
+- `write_pointer`: when `manifest_digest` is empty, OMIT the line entirely (don't write `manifest-digest=`).
+- `read_pointer`: `manifest-digest` becomes optional. If present, validate as before; if absent, treat as empty string.
+- The URI regex widens from `^docker://[A-Za-z0-9._:/@+-]+$` to `^(docker|dockerd|podman)://[A-Za-z0-9._:/@+-]+$`.
+
+A v4-era pointer (with `manifest-digest`) is still valid under the relaxed reader. A new daemon-import pointer (without it) parses cleanly. No magic line bump.
+
+### 3.5 Eviction recovery for daemon URIs
+
+`zfs::create_from_pointer` currently dispatches to `zfs::_pull_and_install_template` (which assumes docker://). Refactor:
+
+```bash
+case "${uri}" in
+    docker://*)
+        fresh_config_sha=$(zfs::_pull_and_install_template "${uri}" "${arch}") ;;
+    dockerd://*|podman://*)
+        fresh_config_sha=$(zfs::_extract_and_install_from_daemon "${uri}" "${arch}") ;;
+    *)
+        common::err "Pointer ${pointer_path} has unsupported URI: ${uri}" ;;
+esac
+```
+
+The new `zfs::_extract_and_install_from_daemon` helper does the same body as `import_daemon_pointer` minus the `write_pointer` step, returns the cache_key.
+
+### 3.6 Wire `runtime::import`
+
+Add a parallel branch in the import dispatcher:
+
+```bash
+case "${uri}" in
+docker://*)
+    if zfs::pointer_format_active; then ... import_docker_pointer
+    else docker::import
+    fi ;;
+dockerd://* | podman://*)
+    if zfs::pointer_format_active; then
+        # filename defaulting (mirror docker::daemon::import's derivation)
+        zfs::import_daemon_pointer "${uri}" "${filename}" "${arch}"
+    else
+        docker::daemon::import "${uri}" "${filename}" "${arch}"
+    fi ;;
+zfs://*) ... unchanged
+*) ... unchanged
+esac
+```
+
+### 3.7 Doc
+
+`doc/zfs.md` already documents the pointer format and inspection recipe. Add a one-paragraph note that `dockerd://` and `podman://` URIs participate in the same cache; the pointer's `enroot:uri` field will show the daemon URI; `manifest-digest` is empty for these.
+
+## 4. Files affected
+
+| File | Change |
+|---|---|
+| `src/storage_zfs.sh` | New `zfs::_install_template_from_dir`. New `zfs::import_daemon_pointer`. New `zfs::_extract_and_install_from_daemon`. Refactor `zfs::create_from_pointer` recovery branch on URI scheme. Relax URI regex in `write_pointer` and `read_pointer`. Make `manifest-digest` optional in both functions. |
+| `src/runtime.sh` | New `dockerd://*\|podman://*` branch in `runtime::import` that calls `zfs::import_daemon_pointer` when pointer format is active. |
+| `doc/zfs.md` | One-paragraph note about daemon-URI cache parity. |
+
+No CLI changes. No `Makefile` / version bump (refinement; ships in next zfs.5 release whenever that lands).
+
+## 5. Trust / security
+
+The pointer regex relax keeps the same shell-metachar exclusion; only the scheme prefix widens. Image IDs from `${engine} inspect` are validated as `^[0-9a-f]{64}$` before they touch any property or pointer field. The empty `manifest-digest` skips its regex entirely (no value, no value to attack).
+
+`zfs::set_template_metadata` (zfs.5 unreleased branch's helper) currently sets `enroot:manifest-digest` unconditionally. Make it skip the property-set when the value is empty so daemon templates don't carry a confusing empty `enroot:manifest-digest=` property.
+
+## 6. Out of scope
+
+- Reproducing the layer cache (`ENROOT_CACHE_PATH`) for daemon URIs. Daemon images are already in the daemon's layer store; we don't try to dedupe across layers.
+- Cross-format conversion (e.g. importing the same image as both `docker://` and `dockerd://` and sharing the cache). Each path computes `image-config-sha256` from a different source — for daemon-pulled images they'll match, but we don't *enforce* it. If they happen to match (which they will for registry-pulled daemon images), they share the cache for free.
+- Dockerd/podman-specific provenance fields (e.g. layer count, parent image). Not needed for the cache key.
+
+## 7. Acceptance
+
+- `enroot import dockerd://ubuntu:24.04 -o /tmp/d.sqsh` writes a < 1 KiB pointer with magic line `enroot-zfs-image:v1`, no `manifest-digest=` line, `enroot-zfs-image:v1`'s `uri=dockerd://...`, populates `${POOL}/.templates/<image-id>`.
+- Repeat `enroot import dockerd://ubuntu:24.04 -o /tmp/d.sqsh` hits the cache (no new template; "Reusing cached template" log).
+- `enroot create -n c1 /tmp/d.sqsh` is `O(zfs clone)` (subseconds).
+- `zfs get enroot:uri ${POOL}/.templates/<image-id>` shows `dockerd://ubuntu:24.04`.
+- Eviction recovery: destroy the template, re-run `enroot create -n c2 /tmp/d.sqsh`, verify it re-extracts from the daemon and clones successfully.
+- `docker://` behavior is unchanged.
+- `--format=squashfs` opt-out still produces a real squashfs for daemon URIs.

--- a/pkg/deb/changelog
+++ b/pkg/deb/changelog
@@ -1,3 +1,27 @@
+#PACKAGE# (4.1.2.zfs.5-1) UNRELEASED; urgency=medium
+
+  * Extend the ZFS pointer cache to `dockerd://` and `podman://` URIs.
+    Daemon imports now produce the same pointer-file artifact as
+    `docker://` imports and populate the layer-keyed template cache
+    (keyed by the daemon-reported image ID); repeat imports hit the
+    cache and `enroot create` becomes O(zfs clone) for those URIs too.
+    Pointer schema gains an optional `manifest-digest` field (omitted
+    for daemon-local images, which have no registry manifest digest).
+
+  * Stash docker provenance as ZFS user properties on each template
+    (`enroot:uri`, `enroot:manifest-digest`, `enroot:arch`,
+    `enroot:imported`). Templates become self-describing — operators
+    can identify cached images via `zfs get` without the (transient)
+    pointer file. Properties replicate via `zfs send -p`.
+
+  * Unmount idle templates after install. `zfs clone <template>@pristine`
+    does not require the source to be mounted, so cached-but-unused
+    templates now sit at zero mountpoints. Only active container clones
+    (and the `.templates` / `.ephemeral` parents) remain visible in
+    `mount(8)` output.
+
+ -- #USERNAME# <#EMAIL#>  Fri, 01 May 2026 22:00:00 +0000
+
 #PACKAGE# (4.1.2.zfs.4-1) UNRELEASED; urgency=medium
 
   * Add ZFS pointer-format import (default on ZFS backend). `enroot

--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -587,7 +587,31 @@ runtime::import() {
         fi
         ;;
     dockerd://* | podman://*)
-        docker::daemon::import "${uri}" "${filename}" "${arch}" ;;
+        if zfs::pointer_format_active; then
+            # ZFS pointer-format daemon import: write a small magic-prefixed
+            # pointer file alongside populating the template cache.
+            # Filename defaulting mirrors docker::daemon::import — daemon URIs
+            # have a `<scheme>://<image-ref>` shape; default filename slugs
+            # the image ref into a .sqsh path.
+            if [ -z "${filename}" ]; then
+                local _image=
+                local -r _reg_image="[[:alnum:]/._:-]+"
+                if [[ "${uri}" =~ ^[[:alpha:]]+://(${_reg_image})$ ]]; then
+                    _image="${BASH_REMATCH[1]}"
+                else
+                    common::err "Invalid image reference: ${uri}"
+                fi
+                filename="${_image//[:\/]/+}.sqsh"
+            fi
+            filename=$(common::realpath "${filename}")
+            if [ -e "${filename}" ]; then
+                common::err "File already exists: ${filename}"
+            fi
+            zfs::import_daemon_pointer "${uri}" "${filename}" "${arch}"
+        else
+            docker::daemon::import "${uri}" "${filename}" "${arch}"
+        fi
+        ;;
     zfs://*)
         zfs::import_uri "${uri}" "${filename}" ;;
     *)

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -1017,3 +1017,68 @@ zfs::_pull_and_install_template() (
 
     printf "%s" "${config}"
 )
+
+# Internal helper used by both the daemon-import flow and the
+# create_from_pointer recovery path for dockerd:// / podman:// URIs. Runs
+# `${engine} create + inspect + export | tar -x`, populates the template
+# from the resulting flat rootfs, prints the resolved
+# image-config-sha256 (the daemon image ID) so the caller can validate
+# it. Does NOT write a pointer file.
+#
+# Inputs:
+#   $1 uri    - dockerd://<image>  or  podman://<image>
+#   $2 arch   - already debarch-normalized (callers must convert with
+#               common::debarch first, or pass the value already stored
+#               in a pointer file).
+#
+# Subshell function for cwd / EXIT trap scoping (matches
+# _pull_and_install_template).
+zfs::_extract_and_install_from_daemon() (
+    local -r uri="$1" arch="$2"
+    local image= tmpdir= engine= cache_key= unpriv=
+    local image_id=
+
+    set -euo pipefail
+
+    case "${uri}" in
+        dockerd://*) engine="docker" ;;
+        podman://*)  engine="podman" ;;
+        *)           common::err "_extract_and_install_from_daemon: not a daemon URI: ${uri}" ;;
+    esac
+
+    common::checkcmd jq "${engine}" tar
+
+    local -r reg_image="[[:alnum:]/._:-]+"
+    if [[ "${uri}" =~ ^[[:alpha:]]+://(${reg_image})$ ]]; then
+        image="${BASH_REMATCH[1]}"
+    else
+        common::err "Invalid image reference: ${uri}"
+    fi
+
+    image_id=$("${engine}" inspect --format '{{.Id}}' "${image}") \
+      || common::err "${engine} inspect ${image} failed"
+    [[ "${image_id}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+      || common::err "${engine} returned unexpected image ID: ${image_id}"
+    cache_key="${image_id#sha256:}"
+
+    trap 'common::rmall "${tmpdir}" 2> /dev/null; "${engine}" rm -f -v "${tmpdir##*/}" > /dev/null 2>&1' EXIT
+    tmpdir=$(common::mktmpdir enroot)
+    common::chdir "${tmpdir}"
+
+    common::log INFO "Extracting image content from ${engine} daemon..." NL
+    "${engine}" create --name "${PWD##*/}" "${image}" >&2
+    mkdir rootfs
+    "${engine}" export "${PWD##*/}" \
+      | tar -C rootfs --warning=no-timestamp --anchored --exclude='dev/*' --exclude='.dockerenv' -px
+    common::fixperms rootfs
+    "${engine}" inspect "${image}" | common::jq '.[] | with_entries(.key|=ascii_downcase)' > config
+    docker::configure rootfs config "${arch}"
+
+    if [ "${EUID}" -ne 0 ]; then
+        unpriv=y
+    fi
+
+    zfs::_install_template_from_dir "${cache_key}" "${PWD}/rootfs" "${unpriv}" > /dev/null
+
+    printf "%s" "${cache_key}"
+)

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -1000,7 +1000,14 @@ zfs::create_from_pointer() (
     # The pointer's `arch` is already debian-normalized (write_pointer
     # was given the normalized form), so pass it straight through to the
     # puller, which expects normalized.
-    fresh_config_sha=$(zfs::_pull_and_install_template "${uri}" "${arch}")
+    case "${uri}" in
+        docker://*)
+            fresh_config_sha=$(zfs::_pull_and_install_template "${uri}" "${arch}") ;;
+        dockerd://*|podman://*)
+            fresh_config_sha=$(zfs::_extract_and_install_from_daemon "${uri}" "${arch}") ;;
+        *)
+            common::err "Pointer ${pointer_path} has unsupported URI scheme: ${uri}" ;;
+    esac
     if [ "${fresh_config_sha}" != "${image_config_sha256}" ]; then
         common::err "Pointer ${pointer_path} references image-config-sha256 ${image_config_sha256:0:12}, but ${uri} now resolves to ${fresh_config_sha:0:12}. Delete and re-import."
     fi

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -926,6 +926,39 @@ zfs::import_docker_pointer() (
     zfs::write_pointer "${output_path}" "${config_sha}" "${manifest_digest}" "${arch}" "${uri}"
 )
 
+# Import flow for dockerd:// / podman:// URIs when the ZFS backend is
+# active and the pointer format is selected. Modeled on
+# import_docker_pointer but uses the daemon-extract path
+# (_extract_and_install_from_daemon). manifest-digest is empty —
+# daemon-local images don't have a registry manifest digest, and the
+# pointer schema (Task 1) makes it optional.
+#
+# Inputs:
+#   $1 uri          - dockerd://<image>  or  podman://<image>
+#   $2 output_path  - where to write the pointer (caller pre-validated)
+#   $3 arch         - raw uname -m form; normalized internally via
+#                     common::debarch.
+zfs::import_daemon_pointer() (
+    local -r uri="$1" output_path="$2"
+    local arch="$3"
+    local cache_key=
+
+    set -euo pipefail
+
+    if [ -n "${arch}" ]; then
+        arch=$(common::debarch "${arch}")
+    fi
+
+    cache_key=$(zfs::_extract_and_install_from_daemon "${uri}" "${arch}")
+
+    local store
+    store=$(zfs::store_dataset)
+    zfs::set_template_metadata "${store}/${zfs_template_subdir}/${cache_key}" \
+        "${uri}" "" "${arch}"
+
+    zfs::write_pointer "${output_path}" "${cache_key}" "" "${arch}" "${uri}"
+)
+
 # Create flow for a ZFS pointer file. Reads the pointer, then either:
 # (a) clones an already-cached template on hit, or
 # (b) re-pulls from the pointer's URI to repopulate an evicted template,

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -811,6 +811,72 @@ zfs::docker_install_from_layers() {
     zfs::clone_container "${template}" "${name}"
 }
 
+# Materializes a flat rootfs directory tree into a ZFS template (cached
+# by cache_key). Counterpart of _install_template_from_layers for callers
+# that already have a single rootfs/ tree (e.g. the dockerd:// / podman://
+# import path, where `${engine} export | tar -x` produces a flat tree, not
+# layered overlayfs directories).
+#
+# Inputs:
+#   $1 cache_key   - sha256 of the image config (the daemon image ID)
+#   $2 source_dir  - directory containing the rootfs to install
+#   $3 unpriv      - "y" or "" — whether to enter a new user namespace
+#
+# Outputs: prints the template dataset path to stdout (no trailing newline).
+#
+# Atomicity: races on the same cache_key are resolved via a per-key .tmp
+# dataset lock; losers wait for @pristine. Same shape as
+# _install_template_from_layers.
+zfs::_install_template_from_dir() {
+    local -r cache_key="$1" source_dir="$2" unpriv="$3"
+    local store template tmp snap mountpoint i=0
+    store=$(zfs::store_dataset)
+    template="${store}/${zfs_template_subdir}/${cache_key}"
+    tmp="${template}.tmp"
+    snap="${template}@${zfs_pristine_snap}"
+
+    zfs::sweep_templates
+
+    zfs create -u "${store}/${zfs_template_subdir}" 2> /dev/null || :
+    enroot-zfs-mount "${store}/${zfs_template_subdir}" 2> /dev/null || :
+
+    if zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; then
+        common::log INFO "Reusing cached template ${cache_key:0:12}"
+        zfs::touch_template "${template}"
+    elif zfs create -u "${tmp}" 2> /dev/null; then
+        if ! enroot-zfs-mount "${tmp}" 2> /dev/null; then
+            zfs destroy "${tmp}" 2> /dev/null || :
+            common::err "failed to mount daemon template"
+        fi
+        mountpoint=$(zfs get -H -o value mountpoint "${tmp}")
+        local copy_cmd
+        copy_cmd="tar --numeric-owner -C '${source_dir}/' --mode=u-s,g-s -cpf - . | tar --numeric-owner -C '${mountpoint}/' -xpf -"
+        if ! enroot-nsenter ${unpriv:+--user} --mount --remap-root bash -c "${copy_cmd}"; then
+            common::log WARN "Daemon template copy failed; evicting all warm templates and retrying"
+            ENROOT_TEMPLATE_WARM_SECONDS=0 zfs::sweep_templates
+            enroot-nsenter ${unpriv:+--user} --mount --remap-root bash -c "${copy_cmd}" \
+              || { zfs destroy -r "${tmp}" 2> /dev/null || :; \
+                   common::err "Failed to copy daemon rootfs into ZFS template even after evicting warm templates"; }
+        fi
+        enroot-zfs-mount --unmount "${tmp}" 2> /dev/null || :
+        zfs rename "${tmp}" "${template}"
+        enroot-zfs-mount "${template}" 2> /dev/null || :
+        zfs snapshot "${snap}"
+        zfs set readonly=on "${template}" 2> /dev/null || :
+        zfs set "enroot:imported=$(date -u +%FT%TZ)" "${template}" 2> /dev/null || :
+        enroot-zfs-mount --unmount "${template}" 2> /dev/null || :
+        zfs::touch_template "${template}"
+    else
+        # Lost the race or stale .tmp — wait for @pristine.
+        while ! zfs list -H -t snapshot "${snap}" > /dev/null 2>&1; do
+            sleep 1
+            ((i++ < 600)) || common::err "Timed out waiting for daemon template: ${template}"
+        done
+    fi
+
+    printf "%s" "${template}"
+}
+
 # Import flow for docker:// URIs when the ZFS backend is active and the
 # pointer format is selected. Pulls layers (via docker::_prepare_layers),
 # fetches the manifest digest (via docker::digest), populates the

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -61,7 +61,9 @@ zfs::touch_template() {
 zfs::set_template_metadata() {
     local -r template="$1" uri="$2" manifest_digest="$3" arch="$4"
     zfs set "enroot:uri=${uri}" "${template}" 2> /dev/null || :
-    zfs set "enroot:manifest-digest=${manifest_digest}" "${template}" 2> /dev/null || :
+    if [ -n "${manifest_digest}" ]; then
+        zfs set "enroot:manifest-digest=${manifest_digest}" "${template}" 2> /dev/null || :
+    fi
     zfs set "enroot:arch=${arch}" "${template}" 2> /dev/null || :
 }
 
@@ -200,11 +202,13 @@ zfs::write_pointer() {
     # space, newline, etc.). The character classes below all forbid them.
     [[ "${config_sha}" =~ ^[0-9a-f]{64}$ ]] \
       || common::err "zfs::write_pointer: invalid image-config-sha256: ${config_sha}"
-    [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
-      || common::err "zfs::write_pointer: invalid manifest-digest: ${manifest_digest}"
+    if [ -n "${manifest_digest}" ]; then
+        [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+          || common::err "zfs::write_pointer: invalid manifest-digest: ${manifest_digest}"
+    fi
     [[ "${arch}" =~ ^[a-z0-9_-]+$ ]] \
       || common::err "zfs::write_pointer: invalid arch: ${arch}"
-    [[ "${uri}" =~ ^docker://[A-Za-z0-9._:/@+-]+$ ]] \
+    [[ "${uri}" =~ ^(docker|dockerd|podman)://[A-Za-z0-9._:/@+-]+$ ]] \
       || common::err "zfs::write_pointer: invalid uri: ${uri}"
 
     imported=$(date -u +%FT%TZ)
@@ -212,7 +216,10 @@ zfs::write_pointer() {
     {
         printf "%s\n" "${zfs_pointer_magic}"
         printf "image-config-sha256=%s\n" "${config_sha}"
-        printf "manifest-digest=%s\n" "${manifest_digest}"
+        # manifest-digest is optional — daemon-local images (dockerd:// /
+        # podman://) don't have a registry manifest digest. Omit the line
+        # entirely when empty so the field's absence is unambiguous.
+        [ -n "${manifest_digest}" ] && printf "manifest-digest=%s\n" "${manifest_digest}"
         printf "arch=%s\n" "${arch}"
         printf "uri=%s\n" "${uri}"
         printf "imported=%s\n" "${imported}"
@@ -250,11 +257,16 @@ zfs::read_pointer() {
     # free of shell metacharacters. The classes below all forbid them.
     [[ "${config_sha}" =~ ^[0-9a-f]{64}$ ]] \
       || common::err "Pointer ${path} missing/invalid image-config-sha256"
-    [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
-      || common::err "Pointer ${path} missing/invalid manifest-digest"
+    # manifest-digest is optional — daemon-local imports (dockerd:// /
+    # podman://) omit it because the daemon doesn't carry a registry
+    # manifest digest. Validate the format only when the field is present.
+    if [ -n "${manifest_digest}" ]; then
+        [[ "${manifest_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] \
+          || common::err "Pointer ${path} invalid manifest-digest"
+    fi
     [[ "${arch}" =~ ^[a-z0-9_-]+$ ]] \
       || common::err "Pointer ${path} missing/invalid arch"
-    [[ "${uri}" =~ ^docker://[A-Za-z0-9._:/@+-]+$ ]] \
+    [[ "${uri}" =~ ^(docker|dockerd|podman)://[A-Za-z0-9._:/@+-]+$ ]] \
       || common::err "Pointer ${path} missing/invalid uri"
     [[ "${imported}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
       || common::err "Pointer ${path} missing/invalid imported timestamp"


### PR DESCRIPTION
## Summary

Extends the zfs.4 pointer cache to `dockerd://` and `podman://` URIs. Daemon imports now write the same magic-prefixed pointer file as `docker://` imports and populate the layer-keyed template cache; repeat imports of the same daemon-local image hit the cache; `enroot create` becomes `O(zfs clone)` for those URIs too.

Cache key is the daemon-reported image ID (`${engine} inspect --format='{{.Id}}'`) — a 64-hex `image-config-sha256` identical in shape and meaning to what `docker::_prepare_layers` produces for a registry pull. So a daemon import of `ubuntu:24.04` shares the cache with a `docker://ubuntu:24.04` registry import for free.

Spec: `docs/superpowers/specs/2026-05-01-zfs-daemon-pointer-design.md`
Plan: `docs/superpowers/plans/2026-05-01-zfs-daemon-pointer.md`

## Schema evolution (still v1)

Daemon-local images don't have a registry manifest digest, so the pointer's `manifest-digest=` field becomes optional. v4 pointers (always with manifest-digest) still parse cleanly under the relaxed reader. The URI regex widens to `^(docker|dockerd|podman)://...` and `set_template_metadata` skips the `enroot:manifest-digest` property when empty.

## What changed

| File | Change |
|---|---|
| `src/storage_zfs.sh` | Optional manifest-digest in `write_pointer`/`read_pointer`. New `_install_template_from_dir` (flat-rootfs analog of `_install_template_from_layers`). New `_extract_and_install_from_daemon` (daemon analog of `_pull_and_install_template`). New `import_daemon_pointer` top-level. Eviction-recovery in `create_from_pointer` dispatches on URI scheme. |
| `src/runtime.sh` | New `dockerd://*\|podman://*` branch in `runtime::import` mirrors the `docker://` branch. |
| `doc/zfs.md` | One-paragraph "Daemon URIs" note under the existing pointer-format section. |

No CLI changes. No version bump in this PR (refinement; ships with whatever zfs.5 picks up next).

## Test plan

- [ ] `enroot import dockerd://ubuntu:24.04 -o /tmp/d.sqsh` writes a < 1 KiB pointer with first line `enroot-zfs-image:v1`, body has `image-config-sha256=`, `arch=`, `uri=dockerd://...`, `imported=`, NO `manifest-digest=` line. New template populated under `${POOL}/.templates/`.
- [ ] `enroot create -n c1 /tmp/d.sqsh` is subseconds; container starts.
- [ ] Repeat `enroot import dockerd://ubuntu:24.04 -o /tmp/d.sqsh` — cache hit ("Reusing cached template" log); template count unchanged.
- [ ] Eviction recovery: destroy template, `enroot create` re-extracts from daemon.
- [ ] `docker://` path unchanged (regression check) — still produces a pointer with `manifest-digest=` line.
- [ ] `--format=squashfs` opt-out still produces a real squashfs for daemon URIs.
- [ ] `podman://` smoke (if podman available on test node).

Closes the daemon-import side of the zfs.4 caching story.
