### PR TITLE
ZFS: auto-remount containers in start/export paths after reboot

### DIFF
--- a/src/runtime.sh
+++ b/src/runtime.sh
@@ -302,6 +302,13 @@ runtime::start() {
         if [[ "${rootfs}" == */* ]]; then
             common::err "Invalid argument: ${rootfs}"
         fi
+        # ZFS containers are created with canmount=noauto, so a freshly-
+        # rebooted host has the dataset present but unmounted. Mount it
+        # idempotently before the directory existence check below — the
+        # cap helper silently no-ops on already-mounted datasets.
+        if zfs::enabled; then
+            zfs::ensure_container_mounted "${rootfs}"
+        fi
         rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs}")
         if [ ! -d "${rootfs}" ]; then
             common::err "No such file or directory: ${rootfs}"
@@ -688,6 +695,13 @@ runtime::_export_sqsh() {
     local rootfs exclude=()
 
     common::checkcmd mksquashfs
+
+    # ZFS containers may be unmounted post-reboot (canmount=noauto + no
+    # boot-time auto-mount); ensure the dataset is mounted before
+    # mksquashfs walks the rootfs path.
+    if zfs::enabled; then
+        zfs::ensure_container_mounted "${rootfs_name}"
+    fi
 
     # Resolve the container rootfs path.
     rootfs=$(common::realpath "${ENROOT_DATA_PATH}/${rootfs_name}")

--- a/src/storage_zfs.sh
+++ b/src/storage_zfs.sh
@@ -385,6 +385,22 @@ zfs::clone_container() {
     fi
 }
 
+# Idempotent-mount a named container's ZFS dataset. ZFS clones are created
+# with canmount=noauto so unprivileged callers don't trigger mount(2)
+# (which needs CAP_SYS_ADMIN) at create time — but that also makes
+# zfs mount -a skip them at boot, leaving the container's mountpoint
+# empty after a reboot. Call this before any path-based access of a
+# named container (start, export-sqsh, …) so the rootfs becomes visible
+# again. enroot-zfs-mount silently no-ops on already-mounted datasets,
+# so this is safe to call unconditionally. Best-effort: an absent
+# dataset is silently ignored; the caller will surface a clearer
+# "no such directory" error a moment later when the existence check
+# fails.
+zfs::ensure_container_mounted() {
+    local -r name="$1"
+    enroot-zfs-mount "$(zfs::store_dataset)/${name}" 2> /dev/null || :
+}
+
 # Destroys a user container. The clone's origin template is left in place;
 # its lifecycle is owned by zfs::sweep_templates (warm/cold/pressure-driven
 # eviction on next create), so a remove + re-create cycle within


### PR DESCRIPTION
Closes #18.

ZFS clones are created with `canmount=noauto` (deliberate — `zfs mount`
needs `CAP_SYS_ADMIN`, so the cap-elevated `enroot-zfs-mount` helper
handles runtime mounting on demand). Side-effect: `zfs mount -a` at boot
skips them, so after a reboot `enroot list` still names the container
(its dataset is intact) but the mountpoint is empty and `enroot start`
errors with `No such file or directory`.

Fix: a small `zfs::ensure_container_mounted` helper that calls
`enroot-zfs-mount` on the named dataset. The cap helper is already
idempotent (silent no-op on already-mounted), so the call is safe to
make every time. Wired into `runtime::start` and `runtime::_export_sqsh`
before each path-walks the rootfs. Templates already get explicit mount
calls in their lifecycle helpers; user containers and exported sqsh
sources were the gap.

## Smoke (spark-ctrl, OpenZFS 2.4.1, 3.75G test pool)

| Test | Result |
| --- | --- |
| Create alpine, `zfs unmount` to simulate reboot, `enroot start` | ✓ auto-remounts, prints `os-release` |
| Idempotent re-start when already mounted | ✓ silent no-op |
| `enroot start <does-not-exist>` | ✓ clean `No such file or directory` |
| `zfs unmount`, `enroot export -o /tmp/x.sqsh <name>` | ✓ auto-remounts, produces valid 8MB squashfs |

## Out of scope

- `enroot list` showing names of unmounted-but-existing datasets is
  pre-existing Plan A behavior. The list command path-walks
  `ENROOT_DATA_PATH`; switching to `zfs list -d 1` for the ZFS backend
  would be more honest but is a follow-up.
- `runtime::_remove_zfs` works through `zfs::destroy_container` which
  doesn't need a mount, so no fix is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)